### PR TITLE
Introduced request recording with 4xx responses

### DIFF
--- a/server/applicationPattern/applicationPattern/commons/AppCommons.js
+++ b/server/applicationPattern/applicationPattern/commons/AppCommons.js
@@ -1,0 +1,99 @@
+// @ts-check
+'use strict';
+
+const operationServerInterface = require('../onfModel/models/layerProtocols/OperationServerInterface');
+const authorizingService = require('../services/AuthorizingService');
+const oamLogService = require('../services/OamLogService');
+const executionAndTraceService = require('../services/ExecutionAndTraceService');
+
+/**
+ * Options for express-openapi-validator middleware
+ */
+const openApiValidatorOptions = {
+    validateRequests: true,
+    validateResponses: true,
+    validateSecurity: {
+        handlers: {
+            apiKeyAuth: validateOperationKey,
+            basicAuth: validateBasicAuth
+        }
+    }
+}
+
+/**
+ * Setup an express application with settings common for all applications.
+ * @param {object} app express Application
+ */
+function setupExpressApp(app) {
+    // format all json responses written via res.json()
+    app.set('json spaces', 2);
+    // remove last middleware, which is errorHandler initialized in oas3Tools ExpressAppConfig constructor
+    app._router.stack.pop();
+    // add custom error handler which logs bad requests
+    app.use(loggingErrorHandler);
+}
+
+/**
+ * Function compares "operation-key" from request header to operation-key from load file.
+ * The function is meant as a handler for validateSecurity option from express-openapi-validator.
+ * @param {object} request express request
+ * @param {string[]} scopes security scopes
+ * @param {object} schema SecuritySchemeObject
+ * @returns {Promise<boolean>} Promise is true when operation keys are equal.
+ */
+async function validateOperationKey(request, scopes, schema) {
+    const operationUuid = await operationServerInterface.getOperationServerUuidAsync(request.url);
+    const operationKeyFromLoadfile = await operationServerInterface.getOperationKeyAsync(operationUuid);
+    const isAuthorized = operationKeyFromLoadfile === request.headers['operation-key'];
+    return isAuthorized;
+}
+
+/**
+ * Function asks AdministratorAdministration application to validate "authorization" header from a request.
+ * The function is meant as a handler for validateSecurity option from express-openapi-validator.
+ * @param {object} request express request
+ * @param {string[]} scopes security scopes
+ * @param {object} schema SecuritySchemeObject
+ * @returns {Promise<boolean>} Promise is true when operation keys are equal.
+ */
+async function validateBasicAuth(request, scopes, schema) {
+    const isAuthorized = await authorizingService.isAuthorized(request.headers.authorization, request.method);
+    return isAuthorized;
+}
+
+/**
+ * Express error handler function which records request/response to ExecutionAndTraceLog or OamLog application.
+ * It is used as last middleware in express application.
+ * @param {object} err express error
+ * @param {object} req express request
+ * @param {object} res express response
+ * @param {function} next express next middleware function
+ */
+function loggingErrorHandler(err, req, res, next) {
+    const statusCode = err.status || 500;
+    const errorBody = {
+        message: err.message,
+        errors: err.errors,
+    }
+    if (statusCode >= 400 && statusCode < 500) { // record client errors
+        if (req.url.startsWith('/core-model')) { // record request for OAM resource
+            oamLogService.recordOamRequest(req.url, req.body, statusCode, req.headers.authorization, req.method);
+        } else { // record request for service resource
+            const xCorrelator = req.headers['x-correlator'];
+            const traceIndicator = req.headers['trace-indicator'];
+            const user = req.headers.user;
+            const originator = req.headers.originator;
+            executionAndTraceService.recordServiceRequest(xCorrelator, traceIndicator, user, originator, req.url, statusCode, req.body, errorBody);
+        }
+    }
+    console.log(`loggingErrorHandler - caught error, returning response with status code "${statusCode}" and body ${JSON.stringify(errorBody)}`);
+    res.status(statusCode).json(errorBody);
+}
+
+module.exports = {
+    openApiValidatorOptions,
+    setupExpressApp,
+    validateOperationKey,
+    validateBasicAuth,
+    loggingErrorHandler
+};

--- a/server/applicationPattern/applicationPattern/rest/client/RequestBuilder.js
+++ b/server/applicationPattern/applicationPattern/rest/client/RequestBuilder.js
@@ -11,10 +11,10 @@ const protocol = "http";
  * @param {string} operationName service that needs to be addressed in the client application 
  * @param {string} method http method for the REST request
  * @param {object} requestHeader http request header for the REST call
- * @param {string} requestBody request body for the REST call
- * @returns {promise} returns the http response received
+ * @param {object} requestBody request body for the REST call
+ * @returns {Promise} returns the http response received
  */
-exports.BuildAndTriggerRestRequest = function (remoteIpAddressAndPort ,operationName, method,  requestHeader, requestBody) {
+exports.BuildAndTriggerRestRequest = function (remoteIpAddressAndPort, operationName, method, requestHeader, requestBody) {
     return new Promise(async function (resolve, reject) {
         try {
             let url = protocol + "://" + remoteIpAddressAndPort + operationName;

--- a/server/applicationPattern/applicationPattern/services/OamLogService.js
+++ b/server/applicationPattern/applicationPattern/services/OamLogService.js
@@ -11,130 +11,136 @@
  * @module OAMLog
  **/
 
- const operationClientInterface = require('../onfModel/models/layerProtocols/OperationClientInterface');
- const HttpServerInterface = require('../onfModel/models/layerProtocols/HttpServerInterface');
- const requestHeader = require('../rest/client/RequestHeader');
- const requestBuilder = require('../rest/client/RequestBuilder');
- const onfAttributeFormatter = require('../onfModel/utility/OnfAttributeFormatter');
- const FcPort = require('../onfModel/models/FcPort');
- const forwardingDomain = require('../onfModel/models/ForwardingDomain');
- const moment = require('moment');
- 
- /**
-  * This function recods the OAM request to the OAM lof application<br>
-  * @param {string} oamPath oam path that is accessed during the request<br>
-  * @param {string} requestBody incase if it is a put request, then the request body of the request<br>
-  * @param {string} responseCode response code of the rest call execution<br>
-  * @param {string} authorizationCode authorization code used to access the oam layer. This will then decoded to findout the username<br>
-  * @param {string} method HTTP method of the OAM layer call. It can be PUT,GET<br>
-  * @returns {Promise<boolean>} returns true if the operation is successful<br>
-  * This method performs the following step,<br>
-  * step 1: Get the operation client of the OAM log application that needs to be executed to log the OAM request <br>
-  * 2. If user value is empty , then the value from originator will be copied<br>
-  * 3. If xCorrelator is empty , then a new X-correlator string will be created by using the method xCorrelatorGenerator<br>
-  * 4. If the customerJourney is empty , then the value "unknown value" will be added<br>
-  * 5. If trace-indicator value is empty , then the value will be assigned to 1<br>
-  */
- exports.recordOamRequest = function (oamPath, requestBody, responseCode, authorizationCode, method) {
-     return new Promise(async function (resolve, reject) {
-         try {
-             let operationClientUuid = await getOperationClientToLogOamRequest();
-             let serviceName = await operationClientInterface.getOperationNameAsync(operationClientUuid);
-             let ipAddressAndPort = await operationClientInterface.getTcpIpAddressAndPortAsyncAsync(operationClientUuid);
-             let operationKey = await operationClientInterface.getOperationKeyAsync(operationClientUuid);
-             let timestamp = moment().format();
-             let applicationName = await HttpServerInterface.getApplicationNameAsync();
-             let releaseNumber = await HttpServerInterface.getReleaseNumberAsync();
-             let userName = decodeAuthorizationCodeAndExtractUserName(authorizationCode);
-             let stringifiedBody = JSON.stringify(requestBody);
-             let httpRequestHeader = onfAttributeFormatter.modifyJsonObjectKeysToKebabCase(new requestHeader(userName, applicationName, "", "", "unknown", operationKey));
-             let httpRequestBody = formulateResponseBody(method, oamPath, stringifiedBody, responseCode, userName, timestamp, applicationName, releaseNumber);
-             let response = await requestBuilder.BuildAndTriggerRestRequest(ipAddressAndPort, serviceName, "POST", httpRequestHeader, httpRequestBody);
-             if (response !== undefined && response.status === 200) {
-                 resolve(true);
-             }
-             resolve(false);
-         } catch (error) {
-             reject(error);
-         }
-     });
- }
- 
- /**
-  * This function formulates the response body with the required attributes that needs to be sent to the OAMLog application<br>
-  * @param {string} method HTTP method of the OAM layer call. It can be PUT,GET<br>
-  * @param {string} oamPath oam path that is accessed during the request<br>
-  * @param {string} stringifiedBody incase if it is a put request, then the request body of the request<br>
-  * @param {string} responseCode response code of the rest call execution<br>
-  * @param {string} userName name of the user who accessed the OAM layer<br>
-  * @param {string} timeStamp timestamp of the execution<br>
-  * @returns {object} return the formulated responseBody<br>
-  */
- function formulateResponseBody(method, oamPath, stringifiedBody, responseCode, userName, timeStamp, applicationName, releaseNumber) {
-     let httpRequestBody = {};
-     try {
-         httpRequestBody = {
-             "application-name": applicationName,
-             "release-number": releaseNumber,
-             "method": method,
-             "resource": oamPath,
-             "stringified-body": stringifiedBody,
-             "response-code": responseCode,
-             "user-name": userName,
-             "timestamp": timeStamp
-         };
-         return httpRequestBody;
-     } catch (error) {
-         console.log(error);
-         return httpRequestBody;
-     }
- }
- 
- 
- async function getOperationClientToLogOamRequest() {
-     return new Promise(async function (resolve, reject) {
-         try {
-             let operationClientUuid = undefined;
-             let forwardingConstruct = await forwardingDomain.getForwardingConstructForTheForwardingNameAsync(
-                 "OamRequestCausesLoggingRequest");
-             if (forwardingConstruct) {
-                 let fcPortList = forwardingConstruct["fc-port"];
-                 for (let i = 0; i < fcPortList.length; i++) {
-                     let fcPort = fcPortList[i];
-                     let fcPortDirection = fcPort["port-direction"];
-                     if (fcPortDirection == FcPort.portDirectionEnum.OUTPUT) {
-                         operationClientUuid = fcPort["logical-termination-point"];
-                     }
-                 }
-             }
-             resolve(operationClientUuid);
-         } catch (error) {
-             reject(error);
-         }
-     });
- }
- 
- /**
-  * @description To decode base64 authorization code from authorization header<br> 
-  * @param {string} authorizationCode base64 encoded authorization code<br>
-  * @returns {string} returns user name based on the decoded authorization code
-  * <b><u>Procedure :</u></b><br>
-  * <b>step 1 :</b> Get the authorization code from the header<br>
-  * <b>step 2 :</b> split the authorization code with delimiter "space" to ignore the prefix "basic" from the authorization code<br>
-  * <b>step 3 :</b> decode the encoded string (which will result in the format username:password)<br>
-  * <b>step 3 :</b> split the text with delimiter ":" to get the username<br>
-  **/
- function decodeAuthorizationCodeAndExtractUserName(authorizationCode) {
-     try {
-         let base64EncodedString = authorizationCode.split(" ")[1];
-         let base64BufferObject = Buffer.from(base64EncodedString, "base64");
-         let base64DecodedString = base64BufferObject.toString("utf8");
-         let userName = base64DecodedString.split(":")[0];
-         console.log("Authorization code : " + authorizationCode);
-         console.log("decoded user name: " + userName);
-         return userName;
-     } catch (error) {
-         console.log(error);
-         return "";
-     }
- }
+const operationClientInterface = require('../onfModel/models/layerProtocols/OperationClientInterface');
+const HttpServerInterface = require('../onfModel/models/layerProtocols/HttpServerInterface');
+const requestHeader = require('../rest/client/RequestHeader');
+const requestBuilder = require('../rest/client/RequestBuilder');
+const onfAttributeFormatter = require('../onfModel/utility/OnfAttributeFormatter');
+const FcPort = require('../onfModel/models/FcPort');
+const forwardingDomain = require('../onfModel/models/ForwardingDomain');
+const moment = require('moment');
+
+/**
+ * This function recods the OAM request to the OAM lof application<br>
+ * @param {string} oamPath oam path that is accessed during the request<br>
+ * @param {object} requestBody incase if it is a put request, then the request body of the request<br>
+ * @param {number} responseCode response code of the rest call execution<br>
+ * @param {string} authorizationCode authorization code used to access the oam layer. This will then decoded to findout the username<br>
+ * @param {string} method HTTP method of the OAM layer call. It can be PUT,GET<br>
+ * @returns {Promise<boolean>} returns true if the operation is successful. Promise is never rejected.<br>
+ * This method performs the following step,<br>
+ * step 1: Get the operation client of the OAM log application that needs to be executed to log the OAM request <br>
+ * 2. If user value is empty , then the value from originator will be copied<br>
+ * 3. If xCorrelator is empty , then a new X-correlator string will be created by using the method xCorrelatorGenerator<br>
+ * 4. If the customerJourney is empty , then the value "unknown value" will be added<br>
+ * 5. If trace-indicator value is empty , then the value will be assigned to 1<br>
+ */
+exports.recordOamRequest = function (oamPath, requestBody, responseCode, authorizationCode, method) {
+    return new Promise(async function (resolve, reject) {
+        let httpRequestBody = {};
+        try {
+            let operationClientUuid = await getOperationClientToLogOamRequest();
+            let serviceName = await operationClientInterface.getOperationNameAsync(operationClientUuid);
+            let ipAddressAndPort = await operationClientInterface.getTcpIpAddressAndPortAsyncAsync(operationClientUuid);
+            let operationKey = await operationClientInterface.getOperationKeyAsync(operationClientUuid);
+            let timestamp = moment().format();
+            let applicationName = await HttpServerInterface.getApplicationNameAsync();
+            let releaseNumber = await HttpServerInterface.getReleaseNumberAsync();
+            let userName = decodeAuthorizationCodeAndExtractUserName(authorizationCode);
+            let stringifiedBody = JSON.stringify(requestBody);
+            let httpRequestHeader = onfAttributeFormatter.modifyJsonObjectKeysToKebabCase(new requestHeader(userName, applicationName, "", "", "unknown", operationKey));
+            httpRequestBody = formulateResponseBody(method, oamPath, stringifiedBody, responseCode, userName, timestamp, applicationName, releaseNumber);
+            let response = await requestBuilder.BuildAndTriggerRestRequest(ipAddressAndPort, serviceName, "POST", httpRequestHeader, httpRequestBody);
+            if (response !== undefined && response.status === 200) {
+                resolve(true);
+            }
+            console.log(`recordOamRequest - record OAM request with body ${JSON.stringify(httpRequestBody)} failed with response status: ${response.status}`);
+            resolve(false);
+        } catch (error) {
+            console.log(`recordOamRequest - record OAM request with body ${JSON.stringify(httpRequestBody)} failed with error: ${error.message}`);
+            resolve(false);
+        }
+    });
+}
+
+/**
+ * This function formulates the response body with the required attributes that needs to be sent to the OAMLog application<br>
+ * @param {string} method HTTP method of the OAM layer call. It can be PUT,GET<br>
+ * @param {string} oamPath oam path that is accessed during the request<br>
+ * @param {string} stringifiedBody incase if it is a put request, then the request body of the request<br>
+ * @param {number} responseCode response code of the rest call execution<br>
+ * @param {string} userName name of the user who accessed the OAM layer<br>
+ * @param {string} timeStamp timestamp of the execution<br>
+ * @returns {object} return the formulated responseBody<br>
+ */
+function formulateResponseBody(method, oamPath, stringifiedBody, responseCode, userName, timeStamp, applicationName, releaseNumber) {
+    let httpRequestBody = {};
+    try {
+        httpRequestBody = {
+            "application-name": applicationName,
+            "release-number": releaseNumber,
+            "method": method,
+            "resource": oamPath,
+            "stringified-body": stringifiedBody,
+            "response-code": responseCode,
+            "user-name": userName,
+            "timestamp": timeStamp
+        };
+        return httpRequestBody;
+    } catch (error) {
+        console.log(error);
+        return httpRequestBody;
+    }
+}
+
+
+async function getOperationClientToLogOamRequest() {
+    return new Promise(async function (resolve, reject) {
+        try {
+            let operationClientUuid = undefined;
+            let forwardingConstruct = await forwardingDomain.getForwardingConstructForTheForwardingNameAsync(
+                "OamRequestCausesLoggingRequest");
+            if (forwardingConstruct) {
+                let fcPortList = forwardingConstruct["fc-port"];
+                for (let i = 0; i < fcPortList.length; i++) {
+                    let fcPort = fcPortList[i];
+                    let fcPortDirection = fcPort["port-direction"];
+                    if (fcPortDirection == FcPort.portDirectionEnum.OUTPUT) {
+                        operationClientUuid = fcPort["logical-termination-point"];
+                    }
+                }
+            }
+            resolve(operationClientUuid);
+        } catch (error) {
+            reject(error);
+        }
+    });
+}
+
+/**
+ * @description To decode base64 authorization code from authorization header<br> 
+ * @param {string} authorizationCode base64 encoded authorization code<br>
+ * @returns {string} returns user name based on the decoded authorization code
+ * <b><u>Procedure :</u></b><br>
+ * <b>step 1 :</b> Get the authorization code from the header<br>
+ * <b>step 2 :</b> split the authorization code with delimiter "space" to ignore the prefix "basic" from the authorization code<br>
+ * <b>step 3 :</b> decode the encoded string (which will result in the format username:password)<br>
+ * <b>step 3 :</b> split the text with delimiter ":" to get the username<br>
+ **/
+function decodeAuthorizationCodeAndExtractUserName(authorizationCode) {
+    if (authorizationCode == undefined) {
+        return "";
+    }
+    try {
+        let base64EncodedString = authorizationCode.split(" ")[1];
+        let base64BufferObject = Buffer.from(base64EncodedString, "base64");
+        let base64DecodedString = base64BufferObject.toString("utf8");
+        let userName = base64DecodedString.split(":")[0];
+        console.log("Authorization code : " + authorizationCode);
+        console.log("decoded user name: " + userName);
+        return userName;
+    } catch (error) {
+        console.log(error);
+        return "";
+    }
+}


### PR DESCRIPTION
oas3-tools returns 4xx responses before requests reach controllers.
It was not possible to record these kind of requests to ExecutionAndTraceLog and OamLog
application.

Solution is to replace error handler middleware which will record such requests.

This commit also introduces AppCommons module which contains common settings
for all applications.

There are also few fixes of logging and jsdocs.

Fixes #124 

Signed-off-by: Martin Sunal <martin.sunal@paxet.io>