### PR TITLE
Request in ActionProfile configurable (fixes #155, #171)

### DIFF
--- a/ApplicationPattern+profileInstances.yaml
+++ b/ApplicationPattern+profileInstances.yaml
@@ -1,56 +1,68 @@
 profile-instances:
 
-  - profile-name: ActionProfile
-    uuid: *-action-p-1000 ## Replace * by ApplicationID and ReleaseNumber
-    operation-name: /v1/start-application-in-generic-representation
-    label: Inform about Application
-    request: https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port][/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-2002/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]
-    display-in-new-browser-window: false
+  - profile-name: 'ActionProfile'
+    uuid: '*-action-p-1000' ## Replace * by ApplicationID and ReleaseNumber
+    capability:
+      operation-name: '/v1/start-application-in-generic-representation'
+      label: 'Inform about Application'
+      display-in-new-browser-window: false
+    configuration:
+      request: 'https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port][/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-2002/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
 
-  - profile-name: ActionProfile
-    uuid: *-action-p-1001 ## Replace * by ApplicationID and ReleaseNumber
-    operation-name: /v1/inform-about-application-in-generic-representation
-    label: Release History
-    request: https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port][/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-2004/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]
-    display-in-new-browser-window: false
+  - profile-name: 'ActionProfile'
+    uuid: '*-action-p-1001' ## Replace * by ApplicationID and ReleaseNumber
+    capability:
+      operation-name: '/v1/inform-about-application-in-generic-representation'
+      label: 'Release History'
+      display-in-new-browser-window: false
+    configuration:
+      request: 'https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port][/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-2004/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
 
-  - profile-name: ActionProfile
-    uuid: *-action-p-1002 ## Replace * by ApplicationID and ReleaseNumber
-    operation-name: /v1/inform-about-application-in-generic-representation
-    label: API Documentation
-    request: https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]/docs
-    display-in-new-browser-window: true
+  - profile-name: 'ActionProfile'
+    uuid: '*-action-p-1002' ## Replace * by ApplicationID and ReleaseNumber
+    capability:
+      operation-name: '/v1/inform-about-application-in-generic-representation'
+      label: 'API Documentation'
+      display-in-new-browser-window: true
+    configuration:
+      request: 'https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]/docs'
 
-  - profile-name: ActionProfile
-    uuid: *-action-p-10?? ## Replace * by ApplicationID and ReleaseNumber and ?? by SequenceNumber
-    operation-name: ## Generic representation operation that shall result in a new button and potentially new input fields
-    label: ## Label of the new button
-    request: ## URL that shall be addressed, as soon as button gets pushed
-    input-value-list:
-      - field-name: ## Label of a field for providing input to the request that gets called by pushing the button
-        unit: ## Unit that shall be represented aside the input field
-      ## Potentially further input fields to be added
-    display-in-new-browser-window: ## to be set on true, if result of pushing the button has to be represented in a new browser window
+  - profile-name: 'ActionProfile'
+    uuid: '*-action-p-10??' ## Replace * by ApplicationID and ReleaseNumber and ?? by SequenceNumber
+    capability:
+      operation-name: ## Generic representation operation that shall result in a new button and potentially new input fields
+      label: ## Label of the new button
+      input-value-list:
+        - field-name: ## Label of a field for providing input to the request that gets called by pushing the button
+          unit: ## Unit that shall be represented aside the input field
+        ## Potentially further input fields to be added
+      display-in-new-browser-window: ## to be set on true, if result of pushing the button has to be represented in a new browser window
+    configuration:
+      request: ## URL that shall be addressed, as soon as button gets pushed
 
   ## Potentially further instances of ActionProfile to be added
 
 
-  - profile-name: IntegerProfile
-    uuid: *-integer-p-10?? ## Replace * by ApplicationID and ReleaseNumber and ?? by SequenceNumber
-    integer-name: ## Name of the Integer attribute
-    unit: ## Unit of the Integer attribute
-    minimum: ## Minimum value to be accepted, while configuration
-    maximum: ## Maximum value to be accepted, while configuration
-    integer-value: ## Current value of the attribute
+  - profile-name: 'IntegerProfile'
+    uuid: '*-integer-p-10??' ## Replace * by ApplicationID and ReleaseNumber and ?? by SequenceNumber
+    capability:
+      integer-name: ## Name of the Integer attribute
+      unit: ## Unit of the Integer attribute
+      minimum: ## Minimum value to be accepted, while configuration
+      maximum: ## Maximum value to be accepted, while configuration
+    configuration:
+      integer-value: ## Current value of the attribute
 
   ## Potentially further instances of IntegerProfile to be added
 
 
-  - profile-name: StringProfile
-    uuid: *-string-p-10?? ## Replace * by ApplicationID and ReleaseNumber and ?? by SequenceNumber
-    string-name: ## Name of the String attribute
-    enumeration: ## Set of allowed values in cornered brackets
-    pattern: ## Regex for validating configuration values
-    string-value: ## Current value of the attribute
+  - profile-name: 'StringProfile'
+    uuid: '*-string-p-10??' ## Replace * by ApplicationID and ReleaseNumber and ?? by SequenceNumber
+    capability:
+      string-name: ## Name of the String attribute
+      enumeration: ## Set of allowed values in cornered brackets
+      pattern: ## Regex for validating configuration values
+    configuration:
+      string-value: ## Current value of the attribute
 
   ## Potentially further instances of StringProfile to be added

--- a/ApplicationPattern+profileInstances.yaml
+++ b/ApplicationPattern+profileInstances.yaml
@@ -18,7 +18,7 @@ profile-instances:
     uuid: *-action-p-1002 ## Replace * by ApplicationID and ReleaseNumber
     operation-name: /v1/inform-about-application-in-generic-representation
     label: API Documentation
-    request: https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]/v1/inform-about-api
+    request: https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]/docs
     display-in-new-browser-window: true
 
   - profile-name: ActionProfile

--- a/ApplicationPattern+profiles.yaml
+++ b/ApplicationPattern+profiles.yaml
@@ -1,31 +1,34 @@
 profiles:
 
-  - profile-name: ActionProfile
-    uuid: string
-      pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
-    operation-name: string
-    label: string
-    request: string
-    input-value-list:
-      - field-name: string
-        unit: string
-    display-in-new-browser-window: boolean
+  - profile-name: 'ActionProfile'
+    uuid: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
+    capability:
+      operation-name: string
+      label: string
+      input-value-list:
+        - field-name: string
+          unit: string
+      display-in-new-browser-window: boolean
+    configuration:
+      request: string
 
-  - profile-name: IntegerProfile
-    uuid: string
-      pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-integer-p-10[0-9]{2}$'
-    integer-name: string
-    unit: string
-    minimum: integer
-    maximum: integer
-    integer-value: integer
+  - profile-name: 'IntegerProfile'
+    uuid: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-integer-p-10[0-9]{2}$'
+    capability:
+      integer-name: string
+      unit: string
+      minimum: integer
+      maximum: integer
+    configuration:
+      integer-value: integer
 
-  - profile-name: StringProfile
-    uuid: string
-      pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-string-p-10[0-9]{2}$'
-    string-name: string
-    enumeration: array
-    pattern: string
-    string-value: string
+  - profile-name: 'StringProfile'
+    uuid: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-string-p-10[0-9]{2}$'
+    capability:
+      string-name: string
+      enumeration: array
+      pattern: string
+    configuration:
+      string-value: string
 
 ## Add further Profile definitions, if required

--- a/ApplicationPattern.yaml
+++ b/ApplicationPattern.yaml
@@ -481,7 +481,7 @@ paths:
                           type: string
                           description: >
                             'Request that shall be called, when button gets pressed
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/request]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
                         input-value-list:
                           type: array
                           uniqueItems: true
@@ -4621,7 +4621,7 @@ paths:
                           type: string
                           description: >
                             'Request that shall be called, when button gets pressed
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/request]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
                         input-value-list:
                           type: array
                           uniqueItems: true
@@ -4838,7 +4838,7 @@ paths:
                           type: string
                           description: >
                             'Request that shall be called, when button gets pressed
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/request]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
                         input-value-list:
                           type: array
                           uniqueItems: true
@@ -5260,20 +5260,18 @@ paths:
                                       type: object
                                       required:
                                         - action-profile-capability
+                                        - action-profile-configuration
                                       properties:
                                         action-profile-capability:
                                           type: object
                                           required:
                                             - operation-name
                                             - label
-                                            - request
                                             - new-browser-window
                                           properties:
                                             operation-name:
                                               type: string
                                             label:
-                                              type: string
-                                            request:
                                               type: string
                                             input-value-list:
                                               type: array
@@ -5288,6 +5286,13 @@ paths:
                                                     type: string
                                             display-in-new-browser-window:
                                               type: boolean
+                                        action-profile-configuration:
+                                          type: object
+                                          required:
+                                            - request
+                                          properties:
+                                            request:
+                                              type: string
                             example:
                               - uuid: '*-0-0-1-integer-p-0000'
                                 profile-name: 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
@@ -6174,6 +6179,258 @@ paths:
 ########################################################################################################################
 #   OAM Layer - Basic Part - Following paths must be copied into every application
 ########################################################################################################################
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/action-profile-1-0:action-profile-pac/action-profile-capability/operation-name:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
+          example: '*-0-0-1-action-p-0000'
+    get:
+      operationId: getActionProfileOperationName
+      summary: 'Returns the name of the Operation'
+      tags:
+        - ActionProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'Operation name provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - action-profile-1-0:operation-name
+                properties:
+                  action-profile-1-0:operation-name:
+                    type: string
+                    example: '/v1/start-application-in-generic-representation'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/action-profile-1-0:action-profile-pac/action-profile-capability/label:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
+          example: '*-action-p-1000'
+    get:
+      operationId: getActionProfileLabel
+      summary: 'Returns the Label of the Action'
+      tags:
+        - ActionProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'Label provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - action-profile-1-0:label
+                properties:
+                  action-profile-1-0:label:
+                    type: string
+                    example: 'Inform about Application'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
+          example: '*-action-p-1000'
+    get:
+      operationId: getActionProfileInputValueListt
+      summary: 'Returns the list of input values'
+      tags:
+        - ActionProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'Input values provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - action-profile-1-0:input-value-list
+                properties:
+                  action-profile-1-0:input-value-list:
+                    type: array
+                    uniqueItems: true
+                    items:
+                      type: object
+                      required:
+                        - field-name
+                      properties:
+                        field-name:
+                          type: string
+                          example: 'Label of input field'
+                        unit:
+                          type: string
+                          example: 'Unit at input field'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/action-profile-1-0:action-profile-pac/action-profile-capability/display-in-new-browser-window:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
+          example: '*-action-p-1000'
+    get:
+      operationId: getActionProfileDisplayInNewBrowserWindow
+      summary: 'Returns whether to be presented in new browser window'
+      tags:
+        - ActionProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'Whether to be presented in new browser window provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - action-profile-1-0:display-in-new-browser-window
+                properties:
+                  action-profile-1-0:display-in-new-browser-window:
+                    type: boolean
+                    example: false
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/action-profile-1-0:action-profile-pac/action-profile-configuration/request:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
+          example: '*-action-p-1000'
+    get:
+      operationId: getActionProfileRequest
+      summary: 'Returns the configured path of the Request'
+      tags:
+        - ActionProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'Request path provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - action-profile-1-0:request
+                properties:
+                  action-profile-1-0:request:
+                    type: string
+                    example: 'https://10.118.125.157:1000/v1/inform-about-application-in-generic-representation'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+    put:
+      operationId: putActionProfileRequest
+      summary: 'Configures path of the Request'
+      tags:
+        - ActionProfile
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - action-profile-1-0:request
+              properties:
+                action-profile-1-0:request:
+                  type: string
+                  example: 'https://10.118.125.157:1000/v1/inform-about-application-in-generic-representation'
+      responses:
+        '204':
+          description: 'Request path configured'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+
+
   /core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name:
     parameters:
       - in: path

--- a/ApplicationPattern.yaml
+++ b/ApplicationPattern.yaml
@@ -4650,7 +4650,7 @@ paths:
                         request: 'https://10.118.125.157:1000/v1/inform-about-release-history-in-generic-representation'
                         display-in-new-browser-window: false
                       - label: 'API Documentation'
-                        request: 'https://10.118.125.157:1000/v1/inform-about-api'
+                        request: 'https://10.118.125.157:1000/docs'
                         display-in-new-browser-window: true
           headers:
             x-correlator:

--- a/doc/SpecifyingApplications/ConceptOfProfileList/ConceptOfProfileList.md
+++ b/doc/SpecifyingApplications/ConceptOfProfileList/ConceptOfProfileList.md
@@ -7,6 +7,7 @@ The ProfileList is a compact notation for designing the Profiles as classes.
 It provides full focus on composing the set of necessary attributes and their datatypes.  
 In case of String datatype, it also allows defining generic expression about the allowed values of the String.  
 This must be applied on the UUIDs and can be applied on any other String attribute.  
+The ProfileList distinguishes invariant and configurable attributes.
 The ProfileList is preparing for defining the individual section of the OaM part of the OpenApiSpecification.  
 
 Definition of the Profiles gives much more freedom to the ApplicationOwner than defining the interfaces.  

--- a/doc/SpecifyingApplications/ConceptOfProfiles/ConceptOfProfiles.md
+++ b/doc/SpecifyingApplications/ConceptOfProfiles/ConceptOfProfiles.md
@@ -36,6 +36,10 @@ UUIDs of Profiles have to comply with the rules defined in [Structure of UUIDs](
 
 **Additional Attributes**  
 The ApplicationOwner is free to define a set of additional attributes in the ProfileList.  
+Attributes have to be substructured into:  
+  * Invariant attributes that are for identifying the instance of Profile (Capability)  
+  * Attributes that are available for storing values during run-time of the application (Configuration)  
+(Capability attributes will only be represented by GET method in the OaM section of the OAS, while Configuration attributes will have PUT method, too.)
 
 
 ### Re-use of Profiles

--- a/doc/SpecifyingApplications/CreatingProfileInstanceList/CreatingProfileInstanceList.md
+++ b/doc/SpecifyingApplications/CreatingProfileInstanceList/CreatingProfileInstanceList.md
@@ -40,11 +40,6 @@ This is a step by step cookbook for creating the ProfileInstanceList.
 **Label**  
 * Fill in the text that shall be printed on the label, which shall be represented in the GenericRepresentation.  
 
-**Request**  
-* Fill in the complete URL that shall be addressed by the GenericRepresentation whenever the button gets pressed.  
-* Several parts (e.g. IP address, TCP port, operationName) of the URL might be subject to the configuration of some interface. These parts have to be substituted by references into the data tree. The references have to be put into cornered brackets "[]".  
-* UUIDs comprised in the references have to match the ServiceList content (otherwise the implementers will fill wrong data into the response bodies of the generic representation requests).  
-
 **InputValueList::FieldName**
 * If the Request needs to send parameters in its body, these parameters have to be defined in the InputValueList.  
 * Don't represent the InputValueList, if not required.  
@@ -58,6 +53,11 @@ This is a step by step cookbook for creating the ProfileInstanceList.
 **DisplayInNewBrowserWindow**  
 * Usually, DisplayInNewBrowserWindow is set on false and the response to the described request will be presented in the same browser window.  
 * If the response to clicking the button shall be represented in a new window of the GenericRepresentation, DisplayInNewBrowserWindow has to be set on true.  
+
+**Request**  
+* Fill in the complete URL that shall be addressed by the GenericRepresentation whenever the button gets pressed.  
+* Several parts (e.g. IP address, TCP port, operationName) of the URL might be subject to the configuration of some interface. These parts have to be substituted by references into the data tree. The references have to be put into cornered brackets "[]".  
+* UUIDs comprised in the references have to match the ServiceList content (otherwise the implementers will fill wrong data into the response bodies of the generic representation requests).  
 
 
 ### Instances of IntegerProfile  

--- a/doc/SpecifyingApplications/CreatingProfileList/CreatingProfileList.md
+++ b/doc/SpecifyingApplications/CreatingProfileList/CreatingProfileList.md
@@ -18,6 +18,8 @@ This is a step by step cookbook for creating the ProfileList.
 * Add required Profile definitions according to the specifications made in [Concept of Profiles](../ConceptOfProfiles/ConceptOfProfiles.md) and [Concept of the ProfileList](../ConceptOfProfileList/ConceptOfProfileList.md) at the end of the file.  
 * Re-using already existing definitions of Profiles from ProfileLists of other applications is very much recommended.  
 * Define patterns for String attributes, wherever reasonable (Potentially [this documentation](https://user.phil.hhu.de/~seyffarth/classes/python2020/09-01%20Regular%20Expressions%20schreiben.html) might be helpful. [Test the Regex](https://regex101.com/).).  
+* Put attributes, which are invariant during runtime of the application into a capability section.  
+* Put attributes, which shall be available for configuration during runtime of the application into a configuration section.  
 
 ### Validation
 


### PR DESCRIPTION
ProfileList substructured into Capability and Configuration.
Regex has been changed from pattern: to String value for YAML to validate.
ProfileInstanceList has now String values in ' '

ProfileInstanceList changed from "/v1/inform-about-api" towards "/docs".
ProfileInstanceList substructured into Capability and Configuration.
ProfileInstanceList has now String values in ' '

Example in OAS changed from "/v1/inform-about-api" towards "/docs".
ActionProfile::request changed from Capability to Configuration in descriptions of services and ControlConstruct.
OAS expanded by ActionProfile definition in basic OaM section.

Concept of Profiles complemented with remark about Capability and Configuration.