### PR TITLE
Adapt AP OAS to UUID rules (fixes #185)

### DIFF
--- a/ApplicationPattern.yaml
+++ b/ApplicationPattern.yaml
@@ -37,13 +37,13 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall be target of the handover process
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0010/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0010/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 new-application-release:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release of application that shall be target of the handover process
-                    find or update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0010/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    find or update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0010/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 new-application-address:
                   type: object
                   minProperties: 1
@@ -60,23 +60,23 @@ paths:
                           pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
                           description: >
                             'IPv4 address of application that shall be target of the handover process
-                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                     domain-name:
                       type: string
                       pattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
                       description: >
                         'Domain name of application that shall be target of the handover process
-                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                 new-application-port:
                   type: integer
                   minimum: 0
                   maximum: 65535
                   description: >
                     'Port of application that shall be target of the handover process
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
               example:
                 new-application-name: 'NewApplicationName'
-                new-application-release: '0.0.2'
+                new-application-release: '2.0.0'
                 new-application-address:
                   ip-address:
                     ipv-4-address: '10.118.125.157'
@@ -113,7 +113,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-1000/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-1000/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -131,7 +131,7 @@ paths:
         # individual callbacks to be added here 
 
         PromptForBequeathingDataCausesRequestForBroadcastingInfoAboutServerReplacement:
-          https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name or /core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port][/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0021/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]:
+          https://[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name or /core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port][/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0021/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]:
             parameters:
               - $ref: '#/components/parameters/user'
               - $ref: '#/components/parameters/originator'
@@ -156,17 +156,17 @@ paths:
                           type: string
                           description: >
                             'Own application name
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         old-application-release-number:
                           type: string
                           description: >
                             'Old release number
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                         new-application-release-number:
                           type: string
                           description: >
                             'Future release number
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0010/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0010/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                         new-application-address:
                           type: object
                           minProperties: 1
@@ -182,21 +182,21 @@ paths:
                                   type: string
                                   description: >
                                     'Future IPv4 address
-                                    from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                                    from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                             domain-name:
                               type: string
                               description: >
                                 'Future domain name
-                                from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                                from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                         new-application-port:
                           type: integer
                           description: >
                             'Future port
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0010/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
                       example:
                         application-name: 'RegistryOffice'
-                        old-application-release-number: '0.0.1'
-                        new-application-release-number: '0.0.2'
+                        old-application-release-number: '1.0.0'
+                        new-application-release-number: '2.0.0'
                         new-application-address:
                           ip-address:
                             ipv-4-address: '10.118.125.157'
@@ -245,7 +245,7 @@ paths:
                 default:
                   $ref: '#/components/responses/responseForErroredServiceRequests'
         PromptForBequeathingDataCausesRequestForDeregisteringOfOldRelease:
-          https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name or /core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port][/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0022/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]:
+          https://[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name or /core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port][/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0022/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]:
             parameters:
               - $ref: '#/components/parameters/user'
               - $ref: '#/components/parameters/originator'
@@ -267,15 +267,15 @@ paths:
                           type: string
                           description: >
                             'Own application name
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         application-release-number:
                           type: string
                           description: >
                             'Own release number
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                       example:
                         application-name: 'BadApplication'
-                        application-release-number: '0.0.1'
+                        application-release-number: '1.0.0'
               responses:
                 '204':
                   description: 'Application deregistered'
@@ -320,7 +320,7 @@ paths:
                 default:
                   $ref: '#/components/responses/responseForErroredServiceRequests'
         PromptingNewReleaseForUpdatingServerCausesRequestForBroadcastingInfoAboutBackwardCompatibleUpdateOfOperation:
-          https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name or /core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port][/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0023/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]:
+          https://[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name or /core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port][/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0023/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]:
             parameters:
               - $ref: '#/components/parameters/user'
               - $ref: '#/components/parameters/originator'
@@ -344,25 +344,25 @@ paths:
                           type: string
                           description: >
                             'Own application name
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         application-release-number:
                           type: string
                           description: >
                             'Own release number
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                         old-operation-name:
                           type: string
                           description: >
                             'Name of the deprecated operation
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-*/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-*/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
                         new-operation-name:
                           type: string
                           description: >
                             'Name of the replacing operation
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-*/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-*/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
                       example:
                         application-name: 'RegistryOffice'
-                        application-release-number: '0.0.2'
+                        application-release-number: '2.0.0'
                         old-operation-name: '/v1/register-application'
                         new-operation-name: '/v2/register-application'
               responses:
@@ -453,7 +453,7 @@ paths:
                           type: string
                           description: >
                             'Own application name
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         datatype:
                           type: string
                           enum:
@@ -476,12 +476,12 @@ paths:
                           type: string
                           description: >
                             'Label that shall be presented on the button
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/label]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/label]'
                         request:
                           type: string
                           description: >
                             'Request that shall be called, when button gets pressed
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
                         input-value-list:
                           type: array
                           uniqueItems: true
@@ -494,17 +494,17 @@ paths:
                                 type: string
                                 description: >
                                   'Name of an input value required for executing the Request
-                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/name]'
+                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/name]'
                               unit:
                                 type: string
                                 description: >
                                   'Unit of an input value required for executing the Request
-                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/unit]'
+                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/unit]'
                         display-in-new-browser-window:
                           type: boolean
                           description: >
                             'True in case Request shall be represented in a new browser window
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/display-in-new-browser-window]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/display-in-new-browser-window]'
                     example:
                       - label: 'Inform about Application'
                         request: 'https://10.118.125.157:1000/v1/inform-about-application-in-generic-representation'
@@ -538,7 +538,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-3000/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-3000/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -587,19 +587,19 @@ paths:
                   type: string
                   description: >
                     'If body provided, name of RegistryOffice application
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0020/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0020/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 registry-office-application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'If body provided, release of RegistryOffice application
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0020/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0020/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 registration-operation:
                   type: string
                   minLength: 6
                   description: >
                     'If body provided, operation for registering
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0020/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0020/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 registry-office-address:
                   type: object
                   minProperties: 1
@@ -616,23 +616,23 @@ paths:
                           pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
                           description: >
                             'If body provided, IPv4 address of RegistryOffice application
-                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                     domain-name:
                       type: string
                       pattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
                       description: >
                         'If body provided, domain name of RegistryOffice application
-                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                 registry-office-port:
                   type: integer
                   minimum: 0
                   maximum: 65535
                   description: >
                     'If body provided, port of RegistryOffice application
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
               example:
                 registry-office-application: 'RegistryOffice'
-                registry-office-application-release-number: '0.0.1'
+                registry-office-application-release-number: '1.0.0'
                 registration-operation: '/v1/register-application'
                 registry-office-address:
                   ip-address:
@@ -670,7 +670,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0000/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0000/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -711,22 +711,22 @@ paths:
                           type: string
                           description: >
                             'Own application name
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         application-release-number:
                           type: string
                           description: >
                             'Own release number
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                         embedding-operation:
                           type: string
                           description: >
                             'Name of service for initiating embedding process
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0001/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0001/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
                         client-update-operation:
                           type: string
                           description: >
                             'Name of service for broadcasting server changes
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0007/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0007/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
                         application-address:
                           type: object
                           minProperties: 1
@@ -742,20 +742,20 @@ paths:
                                   type: string
                                   description: >
                                     'Own IPv4 address
-                                    from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]'
+                                    from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]'
                             domain-name:
                               type: string
                               description: >
                                 'Own domain name
-                                from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/domain-name]'
+                                from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/domain-name]'
                         application-port:
                           type: integer
                           description: >
                             'Own TCP port
-                            from[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]'
+                            from[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]'
                       example:
                         application-name: 'OwnApplicationName'
-                        application-release-number: '0.0.1'
+                        application-release-number: '1.0.0'
                         embedding-operation: '/v1/embed-yourself'
                         client-update-operation: '/v1/update-client'
                         application-address:
@@ -838,31 +838,31 @@ paths:
                   type: string
                   description: >
                     'Name of RegistryOffice application
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0020/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0020/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 registry-office-application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release of RegistryOffice application
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0020/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0020/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 relay-server-replacement-operation:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for requesting for broadcasting a new server address
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0021/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0021/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 relay-operation-update-operation:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for requesting for broadcasting a backward compatible replacement of an operation
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0023/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0023/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 deregistration-operation:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for deregistering from the application layer
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0022/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0022/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 registry-office-address:
                   type: object
                   minProperties: 1
@@ -879,23 +879,23 @@ paths:
                           pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
                           description: >
                             'IPv4 address of RegistryOffice application
-                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                     domain-name:
                       type: string
                       pattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
                       description: >
                         'Domain name of RegistryOffice application
-                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                 registry-office-port:
                   type: integer
                   minimum: 0
                   maximum: 65535
                   description: >
                     'Port of RegistryOffice application
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0020/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
               example:
                 registry-office-application: 'RegistryOffice'
-                registry-office-application-release-number: '0.0.1'
+                registry-office-application-release-number: '1.0.0'
                 relay-server-replacement-operation: '/v1/relay-server-replacement'
                 relay-operation-update-operation: '/v1/relay-operation-update'
                 deregistration-operation: '/v1/deregister-application'
@@ -935,7 +935,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0001/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0001/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -950,7 +950,7 @@ paths:
           $ref: '#/components/responses/responseForErroredServiceRequests'
       callbacks:
         PromptForEmbeddingCausesRequestForBequeathingData:
-          https://[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0000/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name or /core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0000/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0000/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port][/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0000/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]:
+          https://[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0000/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name or /core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0000/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]:[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0000/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port][/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0000/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]:
             parameters:
               - $ref: '#/components/parameters/user'
               - $ref: '#/components/parameters/originator'
@@ -974,12 +974,12 @@ paths:
                           type: string
                           description: >
                             'Own application name
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         new-application-release:
                           type: string
                           description: >
                             'Own release number
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                         new-application-address:
                           type: object
                           minProperties: 1
@@ -995,20 +995,20 @@ paths:
                                   type: string
                                   description: >
                                     'Own IPv4 address
-                                    from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]'
+                                    from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/ipv-4-address]'
                             domain-name:
                               type: string
                               description: >
                                 'Own domain-name
-                                from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/domain-name]'
+                                from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-address/domain-name]'
                         new-application-port:
                           type: integer
                           description: >
                             'Own TCP port
-                            from[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]'
+                            from[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port]'
                       example:
                         new-application-name: 'OwnApplicationName'
-                        new-application-release: '0.0.2'
+                        new-application-release: '2.0.0'
                         new-application-address:
                           ip-address:
                             ipv-4-address: '10.118.125.157'
@@ -1088,19 +1088,19 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall record the service requests
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0040/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0040/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 service-log-application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release of application that shall record the service requests
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0040/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0040/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 service-log-operation:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for recording the service requests
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0040/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0040/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 service-log-address:
                   type: object
                   minProperties: 1
@@ -1117,23 +1117,23 @@ paths:
                           pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
                           description: >
                             'IPv4 address of application that shall record the service requests
-                            update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0040/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                            update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0040/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                     domain-name:
                       type: string
                       pattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
                       description: >
                         'Domain name of application that shall record the service requests
-                        update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0040/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                        update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0040/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                 service-log-port:
                   type: integer
                   minimum: 0
                   maximum: 65535
                   description: >
                     'Port of application that shall record the service requests
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0040/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0040/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
               example:
                 service-log-application: 'ExecutionAndTraceLog'
-                service-log-application-release-number: '0.0.1'
+                service-log-application-release-number: '1.0.0'
                 service-log-operation: '/v1/record-service-request'
                 service-log-address:
                   ip-address:
@@ -1171,7 +1171,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0002/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0002/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -1224,32 +1224,32 @@ paths:
                           description: 'ApplicationName on the client side; as defined in all service headers [originator]'
                         application-name:
                           type: string
-                          description: '[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                          description: '[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         release-number:
                           type: string
-                          description: '[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
+                          description: '[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                         operation-name:
                           type: string
-                          description: '[/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-*/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
+                          description: '[/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-*/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
                         response-code:
                           type: integer
                           description: 'Response code sent to [originator] after invoking [operation-name] at [application-name]'
                         timestamp:
                           type: string
-                          description: 'Date and time when [application-name] sent response to [originator]; only to be provided, if [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0040/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/detailed-logging-is-on] == true'
+                          description: 'Date and time when [application-name] sent response to [originator]; only to be provided, if [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0040/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/detailed-logging-is-on] == true'
                         stringified-body:
                           type: string
-                          description: 'Stringified body of the request addressed from [originator] to [application-name]; only to be provided, if [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0040/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/detailed-logging-is-on] == true'
+                          description: 'Stringified body of the request addressed from [originator] to [application-name]; only to be provided, if [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0040/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/detailed-logging-is-on] == true'
                         stringified-response:
                           type: string
-                          description: 'Stringified response sent from [application-name] to [originator]; only to be provided, if [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0040/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/detailed-logging-is-on] == true'
+                          description: 'Stringified response sent from [application-name] to [originator]; only to be provided, if [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0040/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/detailed-logging-is-on] == true'
                       example:
                         x-correlator: '550e8400-e29b-11d4-a716-446655440000'
                         trace-indicator: '1.1'
                         user: 'User Name'
                         originator: 'RegistryOffice'
                         application-name: 'OwnApplicationName'
-                        release-number: '0.0.1'
+                        release-number: '1.0.0'
                         operation-name: '/v1/embed-yourself'
                         response-code: 500
                         timestamp: '2010-11-20T14:00:00+01:00'
@@ -1329,19 +1329,19 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall record the OaM requests
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0050/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0050/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 oam-log-application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release of application that shall record the OaM request
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0050/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0050/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 oam-log-operation:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for recording the OaM requests
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0050/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0050/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 oam-log-address:
                   type: object
                   minProperties: 1
@@ -1358,23 +1358,23 @@ paths:
                           pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
                           description: >
                             'IPv4 address of application that shall record the OaM requests
-                            update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0050/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                            update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0050/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                     domain-name:
                       type: string
                       pattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
                       description: >
                         'Domain name of application that shall record the OaM requests
-                        update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0050/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                        update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0050/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                 oam-log-port:
                   type: integer
                   minimum: 0
                   maximum: 65535
                   description: >
                     'Port of application that shall record the OaM requests
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0050/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0050/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
               example:
                 oam-log-application: 'OamLog'
-                oam-log-application-release-number: '0.0.1'
+                oam-log-application-release-number: '1.0.0'
                 oam-log-operation: '/v1/record-oam-request'
                 oam-log-address:
                   ip-address:
@@ -1412,7 +1412,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0003/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0003/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -1455,12 +1455,12 @@ paths:
                           type: string
                           description: >
                             'Own application name 
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         release-number:
                           type: string
                           description: >
                             'Own release number
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                         method:
                           type: string
                           description: 'Method applied in the OaM request, which is to be recorded'
@@ -1481,9 +1481,9 @@ paths:
                           description: 'Date and time when the response to the OaM request, which is to be recorded, has been sent'
                       example:
                         application-name: 'OwnApplicationName'
-                        release-number: '0.0.1'
+                        release-number: '1.0.0'
                         method: 'PUT'
-                        resource: '/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port'
+                        resource: '/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-s-0000/layer-protocol=0/tcp-server-interface-1-0:tcp-server-interface-pac/tcp-server-interface-configuration/local-port'
                         stringified-body: '{"tcp-server-interface-1-0:local-port":"1000"}'
                         response-code: 204
                         user-name: 'Max Mustermann'
@@ -1560,22 +1560,22 @@ paths:
                   type: string
                   description: >
                     'Name of application that no longer wants to receive notifications
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 subscriber-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release of application that no longer wants to receive notifications
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 subscription:
                   type: string
                   minLength: 6
                   description: >
                     'Name of operation that had been addressed for starting getting notifications
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-*/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-*/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-capability/operation-name]'
               example:
                 subscriber-application: 'AlreadySubscribingApplication'
-                subscriber-release-number: '0.0.1'
+                subscriber-release-number: '1.0.0'
                 subscription: '/v1/subscription-to-be-stopped'
       responses:
         '204':
@@ -1609,7 +1609,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0004/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0004/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -1653,19 +1653,19 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall approve the OaM requests
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0060/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0060/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 oam-approval-application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release of application that shall approve the OaM requests
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0060/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0060/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 oam-approval-operation:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for approving the OaM requests
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0060/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0060/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 oam-approval-address:
                   type: object
                   minProperties: 1
@@ -1682,23 +1682,23 @@ paths:
                           pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
                           description: >
                             'IPv4 address of application that shall approve the OaM requests
-                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0060/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0060/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                     domain-name:
                       type: string
                       pattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
                       description: >
                         'Domain name of application that shall approve the OaM requests
-                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0060/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0060/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                 oam-approval-port:
                   type: integer
                   minimum: 0
                   maximum: 65535
                   description: >
                     'Port of application that shall approve the OaM requests
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0060/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0060/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
               example:
                 oam-approval-application: 'AdministratorAdministration'
-                oam-approval-application-release-number: '0.0.1'
+                oam-approval-application-release-number: '1.0.0'
                 oam-approval-operation: '/v1/approve-oam-request'
                 oam-approval-address:
                   ip-address:
@@ -1736,7 +1736,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0003/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0003/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -1775,12 +1775,12 @@ paths:
                           type: string
                           description: >
                             'Own application name for the AdministratorAdministration to check, whether this application is part of the SDN at all
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                         release-number:
                           type: string
                           description: >
                             'Own application release number for the AdministratorAdministration to check, whether this application is part of the SDN at all
-                            from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
+                            from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                         Authorization:
                           type: string
                           description: > 
@@ -1800,7 +1800,7 @@ paths:
                           description: 'Method applied in the OaM request, which is to be recorded'
                       example:
                         application-name: 'OwnApplicationName'
-                        release-number: '0.0.1'
+                        release-number: '1.0.0'
                         Authorization: 'Basic PEJhc2ljIEF1dGggVXNlcm5hbWU+OjxCYHduEdBBdXRoIFBhc3N3b3JkPg=='
                         method: 'PUT'
               responses:
@@ -1905,19 +1905,19 @@ paths:
                   type: string
                   description: >
                     'Name of the application that has updated connection data
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 old-application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Currently addressed release of the application that has updated connection data
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 new-application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Future release number of the application that has updated connection data
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 new-application-address:
                   type: object
                   minProperties: 1
@@ -1934,24 +1934,24 @@ paths:
                           pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
                           description: >
                             'Future IPv4 address of the application that has updated connection data
-                            update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                            update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                     domain-name:
                       type: string
                       pattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
                       description: >
                         'Future domain name of the application that has updated connection data
-                        update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                        update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                 new-application-port:
                   type: integer
                   minimum: 0
                   maximum: 65535
                   description: >
                     'Future port of the application that has updated connection data
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-*/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
               example:
                 application-name: 'RegistryOffice'
-                old-application-release-number: '0.0.1'
-                new-application-release-number: '0.0.2'
+                old-application-release-number: '1.0.0'
+                new-application-release-number: '2.0.0'
                 new-application-address:
                   ip-address:
                     ipv-4-address: '10.118.125.157'
@@ -1988,7 +1988,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0007/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0007/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -2264,10 +2264,10 @@ paths:
                                               remote-port:
                                                 type: integer
                         example:
-                          - uuid: '*-0-0-1-op-s-0000'
+                          - uuid: 'ro-1-0-0-op-s-0000'
                             ltp-direction: 'core-model-1-4:TERMINATION_DIRECTION_SOURCE'
                             client-ltp: []
-                            server-ltp: ['*-0-0-1-http-s-0000']
+                            server-ltp: ['ro-1-0-0-http-s-0000']
                             layer-protocol:
                               - local-id: '0'
                                 layer-protocol-name: 'operation-server-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_OPERATION_LAYER'
@@ -2276,9 +2276,9 @@ paths:
                                     operation-name: '/v1/register-yourself'
                                   operation-server-interface-configuration:
                                     life-cycle-state: 'operation-server-interface-1-0:LIFE_CYCLE_STATE_TYPE_EXPERIMENTAL'
-                          - uuid: '*-0-0-1-http-s-0000'
+                          - uuid: 'ro-1-0-0-http-s-0000'
                             ltp-direction: 'core-model-1-4:TERMINATION_DIRECTION_SOURCE'
-                            client-ltp: ['*-0-0-1-op-s-0000']
+                            client-ltp: ['ro-1-0-0-op-s-0000']
                             server-ltp: []
                             layer-protocol:
                               - local-id: '0'
@@ -2286,7 +2286,7 @@ paths:
                                 http-server-interface-1-0:http-server-interface-pac:
                                   http-server-interface-capability:
                                     application-name: 'RegistryOffice'
-                                    release-number: '0.0.1'
+                                    release-number: '1.0.0'
                                     data-update-period: 'http-server-interface-1-0:DATA_UPDATE_PERIOD_TYPE_REAL_TIME'
                       forwarding-domain:
                         type: array
@@ -2339,9 +2339,9 @@ paths:
                                         logical-termination-point:
                                           type: string
                         example:
-                          - uuid: '*-0-0-1-op-fd-0000'
+                          - uuid: 'ro-1-0-0-op-fd-0000'
                             forwarding-construct:
-                              - uuid: '*-0-0-1-op-fc-0000'
+                              - uuid: 'ro-1-0-0-op-fc-0000'
                                 name:
                                   - value-name: 'ForwardingKind'
                                     value: 'core-model-1-4:FORWARDING_KIND_TYPE_INVARIANT_PROCESS_SNIPPET'
@@ -2350,11 +2350,11 @@ paths:
                                 fc-port:
                                   - local-id: '000'
                                     port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_MANAGEMENT'
-                                    logical-termination-point: '*-0-0-1-op-s-0000'
+                                    logical-termination-point: 'ro-1-0-0-op-s-0000'
                                   - local-id: '100'
                                     port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_INPUT'
-                                    logical-termination-point: '*-0-0-1-op-s-0000'
-                              - uuid: '*-0-0-1-op-fc-0001'
+                                    logical-termination-point: 'ro-1-0-0-op-s-0000'
+                              - uuid: 'ro-1-0-0-op-fc-0001'
                                 name:
                                   - value-name: 'ForwardingKind'
                                     value: 'core-model-1-4:FORWARDING_KIND_TYPE_INVARIANT_PROCESS_SNIPPET'
@@ -2363,10 +2363,10 @@ paths:
                                 fc-port:
                                   - local-id: '100'
                                     port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_INPUT'
-                                    logical-termination-point: '*-0-0-1-op-s-0001'
+                                    logical-termination-point: 'ro-1-0-0-op-s-0001'
                                   - local-id: '200'
                                     port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_OUTPUT'
-                                    logical-termination-point: '*-0-0-1-op-c-0020'
+                                    logical-termination-point: 'ro-1-0-0-op-c-0020'
           headers:
             x-correlator:
               schema: 
@@ -2396,7 +2396,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0008/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0008/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -2445,49 +2445,49 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall document the application layer topology
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0070/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0070/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 topology-application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release of application that shall document the application layer topology
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-0070/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-0070/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 topology-operation-application-update:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for updating the entire information about an application
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0070/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0070/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 topology-operation-ltp-update:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for updating an LTP
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0071/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0071/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 topology-operation-ltp-deletion:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for deleting an LTP
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0072/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0072/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 topology-operation-fc-update:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for updating an FC port
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0073/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0073/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 topology-operation-fc-port-update:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for updating an FC port
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0074/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0074/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 topology-operation-fc-port-deletion:
                   type: string
                   minLength: 6
                   description: >
                     'Operation for deleting an FC port
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-0075/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-0075/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 topology-application-address:
                   type: object
                   minProperties: 1
@@ -2504,23 +2504,23 @@ paths:
                           pattern: '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
                           description: >
                             'IPv4 address of application that shall document the application layer topology
-                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0070/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
+                            update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0070/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/ip-address/ipv-4-address]'
                     domain-name:
                       type: string
                       pattern: '^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$'
                       description: >
                         'Domain name of application that shall document the application layer topology
-                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0070/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
+                        update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0070/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-address/domain-name]'
                 topology-application-port:
                   type: integer
                   minimum: 0
                   maximum: 65535
                   description: >
                     'Port of application that shall document the application layer topology
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-tcp-c-0070/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
+                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-tcp-c-0070/layer-protocol=0/tcp-client-interface-1-0:tcp-client-interface-pac/tcp-client-interface-configuration/remote-port]'
               example:
                 topology-application: 'ApplicationLayerTopology'
-                topology-application-release-number: '0.0.1'
+                topology-application-release-number: '1.0.0'
                 topology-operation-application-update: '/v1/update-all-ltps-and-fcs'
                 topology-operation-ltp-update: '/v1/update-ltp'
                 topology-operation-ltp-deletion: '/v1/delete-ltp-and-dependents'
@@ -2563,7 +2563,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0009/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0009/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -2835,10 +2835,10 @@ paths:
                                                     remote-port:
                                                       type: integer
                               example:
-                                - uuid: '*-0-0-1-op-s-0000'
+                                - uuid: 'ro-1-0-0-op-s-0000'
                                   ltp-direction: 'core-model-1-4:TERMINATION_DIRECTION_SOURCE'
                                   client-ltp: []
-                                  server-ltp: ['*-0-0-1-http-s-0000']
+                                  server-ltp: ['ro-1-0-0-http-s-0000']
                                   layer-protocol:
                                     - local-id: '0'
                                       layer-protocol-name: 'operation-server-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_OPERATION_LAYER'
@@ -2847,9 +2847,9 @@ paths:
                                           operation-name: '/v1/register-yourself'
                                         operation-server-interface-configuration:
                                           life-cycle-state: 'operation-server-interface-1-0:LIFE_CYCLE_STATE_TYPE_EXPERIMENTAL'
-                                - uuid: '*-0-0-1-http-s-0000'
+                                - uuid: 'ro-1-0-0-http-s-0000'
                                   ltp-direction: 'core-model-1-4:TERMINATION_DIRECTION_SOURCE'
-                                  client-ltp: ['*-0-0-1-op-s-0000']
+                                  client-ltp: ['ro-1-0-0-op-s-0000']
                                   server-ltp: []
                                   layer-protocol:
                                     - local-id: '0'
@@ -2857,7 +2857,7 @@ paths:
                                       http-server-interface-1-0:http-server-interface-pac:
                                         http-server-interface-capability:
                                           application-name: 'RegistryOffice'
-                                          release-number: '0.0.1'
+                                          release-number: '1.0.0'
                                           data-update-period: 'http-server-interface-1-0:DATA_UPDATE_PERIOD_TYPE_REAL_TIME'
                             forwarding-domain:
                               type: array
@@ -2910,9 +2910,9 @@ paths:
                                               logical-termination-point:
                                                 type: string
                               example:
-                                - uuid: '*-0-0-1-op-fd-0000'
+                                - uuid: 'ro-1-0-0-op-fd-0000'
                                   forwarding-construct:
-                                    - uuid: '*-0-0-1-op-fc-0000'
+                                    - uuid: 'ro-1-0-0-op-fc-0000'
                                       name:
                                         - value-name: 'ForwardingKind'
                                           value: 'core-model-1-4:FORWARDING_KIND_TYPE_INVARIANT_PROCESS_SNIPPET'
@@ -2921,11 +2921,11 @@ paths:
                                       fc-port:
                                         - local-id: '000'
                                           port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_MANAGEMENT'
-                                          logical-termination-point: '*-0-0-1-op-s-0000'
+                                          logical-termination-point: 'ro-1-0-0-op-s-0000'
                                         - local-id: '100'
                                           port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_INPUT'
-                                          logical-termination-point: '*-0-0-1-op-s-0000'
-                                    - uuid: '*-0-0-1-op-fc-0001'
+                                          logical-termination-point: 'ro-1-0-0-op-s-0000'
+                                    - uuid: 'ro-1-0-0-op-fc-0001'
                                       name:
                                         - value-name: 'ForwardingKind'
                                           value: 'core-model-1-4:FORWARDING_KIND_TYPE_INVARIANT_PROCESS_SNIPPET'
@@ -2934,10 +2934,10 @@ paths:
                                       fc-port:
                                         - local-id: '100'
                                           port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_INPUT'
-                                          logical-termination-point: '*-0-0-1-op-s-0001'
+                                          logical-termination-point: 'ro-1-0-0-op-s-0001'
                                         - local-id: '200'
                                           port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_OUTPUT'
-                                          logical-termination-point: '*-0-0-1-op-c-0020'
+                                          logical-termination-point: 'ro-1-0-0-op-c-0020'
               responses:
                 '204':
                   description: 'LTPs and FD will be updated'
@@ -3222,10 +3222,10 @@ paths:
                                           remote-port:
                                             type: integer
                       example:
-                        uuid: '*-0-0-1-op-s-0002'
+                        uuid: 'ro-1-0-0-op-s-0002'
                         ltp-direction: 'core-model-1-4:TERMINATION_DIRECTION_SOURCE'
                         client-ltp: []
-                        server-ltp: ['*-0-0-1-http-s-0000']
+                        server-ltp: ['ro-1-0-0-http-s-0000']
                         layer-protocol:
                           - local-id: '0'
                             layer-protocol-name: 'operation-server-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_OPERATION_LAYER'
@@ -3299,7 +3299,7 @@ paths:
                         uuid:
                           type: string
                       example:
-                        uuid: '*-0-0-1-op-s-0002'
+                        uuid: 'ro-1-0-0-op-s-0002'
               responses:
                 '204':
                   description: 'LTP will be deleted'
@@ -3394,7 +3394,7 @@ paths:
                               logical-termination-point:
                                 type: string
                       example:
-                        uuid: '*-0-0-1-op-fc-0003'
+                        uuid: 'ro-1-0-0-op-fc-0003'
                         name:
                           - value-name: 'ForwardingKind'
                             value: 'core-model-1-4:FORWARDING_KIND_TYPE_INVARIANT_PROCESS_SNIPPET'
@@ -3403,10 +3403,10 @@ paths:
                         fc-port:
                           - local-id: '000'
                             port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_MANAGEMENT'
-                            logical-termination-point: '*-0-0-1-op-s-0003'
+                            logical-termination-point: 'ro-1-0-0-op-s-0003'
                           - local-id: '200'
                             port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_OUTPUT'
-                            logical-termination-point: '*-0-0-1-op-c-0050'
+                            logical-termination-point: 'ro-1-0-0-op-c-0050'
               responses:
                 '204':
                   description: 'FC will be updated'
@@ -3490,11 +3490,11 @@ paths:
                             logical-termination-point:
                               type: string
                       example:
-                        fc-uuid: '*-0-0-1-op-fc-0003'
+                        fc-uuid: 'ro-1-0-0-op-fc-0003'
                         fc-port:
                           local-id: '000'
                           port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_MANAGEMENT'
-                          logical-termination-point: '*-0-0-1-op-s-0003'
+                          logical-termination-point: 'ro-1-0-0-op-s-0003'
               responses:
                 '204':
                   description: 'FC port will be updated'
@@ -3563,7 +3563,7 @@ paths:
                         fc-port-local-id:
                           type: string
                       example:
-                        fc-uuid: '*-0-0-1-op-fc-3000'
+                        fc-uuid: 'ro-1-0-0-op-fc-3000'
                         fc-port-local-id: '202'
               responses:
                 '204':
@@ -3849,10 +3849,10 @@ paths:
                                           remote-port:
                                             type: integer
                       example:
-                        uuid: '*-0-0-1-op-s-0002'
+                        uuid: 'ro-1-0-0-op-s-0002'
                         ltp-direction: 'core-model-1-4:TERMINATION_DIRECTION_SOURCE'
                         client-ltp: []
-                        server-ltp: ['*-0-0-1-http-s-0000']
+                        server-ltp: ['ro-1-0-0-http-s-0000']
                         layer-protocol:
                           - local-id: '0'
                             layer-protocol-name: 'operation-server-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_OPERATION_LAYER'
@@ -3926,7 +3926,7 @@ paths:
                         uuid:
                           type: string
                       example:
-                        uuid: '*-0-0-1-op-s-0002'
+                        uuid: 'ro-1-0-0-op-s-0002'
               responses:
                 '204':
                   description: 'LTP will be deleted'
@@ -4021,7 +4021,7 @@ paths:
                               logical-termination-point:
                                 type: string
                       example:
-                        uuid: '*-0-0-1-op-fc-0003'
+                        uuid: 'ro-1-0-0-op-fc-0003'
                         name:
                           - value-name: 'ForwardingKind'
                             value: 'core-model-1-4:FORWARDING_KIND_TYPE_INVARIANT_PROCESS_SNIPPET'
@@ -4030,10 +4030,10 @@ paths:
                         fc-port:
                           - local-id: '000'
                             port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_MANAGEMENT'
-                            logical-termination-point: '*-0-0-1-op-s-0003'
+                            logical-termination-point: 'ro-1-0-0-op-s-0003'
                           - local-id: '200'
                             port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_OUTPUT'
-                            logical-termination-point: '*-0-0-1-op-c-0050'
+                            logical-termination-point: 'ro-1-0-0-op-c-0050'
               responses:
                 '204':
                   description: 'FC port will be updated'
@@ -4117,11 +4117,11 @@ paths:
                             logical-termination-point:
                               type: string
                       example:
-                        fc-uuid: '*-0-0-1-op-fc-0003'
+                        fc-uuid: 'ro-1-0-0-op-fc-0003'
                         fc-port:
                           local-id: '000'
                           port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_MANAGEMENT'
-                          logical-termination-point: '*-0-0-1-op-s-0003'
+                          logical-termination-point: 'ro-1-0-0-op-s-0003'
               responses:
                 '204':
                   description: 'FC port will be updated'
@@ -4190,7 +4190,7 @@ paths:
                         fc-port-local-id:
                           type: string
                       example:
-                        fc-uuid: '*-0-0-1-op-fc-3000'
+                        fc-uuid: 'ro-1-0-0-op-fc-3000'
                         fc-port-local-id: '202'
               responses:
                 '204':
@@ -4261,7 +4261,7 @@ paths:
               properties:
                 operation-uuid:
                   type: string
-                  pattern: '^[a-z]+-\d+-\d+-\d+-op-s-\d{4}$'
+                  pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-s-([0-3])0([0-9,a-f]{2})$'
                   description: >
                     'UUID of LTP that is target of the updating of the operation key
                     find [/core-model-1-4:control-construct/logical-termination-point=uuid]'
@@ -4272,7 +4272,7 @@ paths:
                     'Future operation key
                     update [/core-model-1-4:control-construct/logical-termination-point={operation-uuid}/layer-protocol=0/operation-*-interface-1-0:operation-*-interface-pac/operation-*-interface-configuration/operation-key]'
               example:
-                operation-uuid: 'ro-0-0-1-op-s-3003'
+                operation-uuid: 'ro-1-0-0-op-s-3003'
                 new-operation-key: 'Operation key not yet provided.'
       responses:
         '204':
@@ -4306,7 +4306,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0010/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0010/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -4349,28 +4349,28 @@ paths:
                   type: string
                   description: >
                     'Name of the application that has an updated operation
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
                 application-release-number:
                   type: string
-                  pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
+                  pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release number of the application that has an updated operation
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 old-operation-name:
                   type: string
                   minLength: 6
                   description: >
                     'Name of the deprecated operation
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-*/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-*/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
                 new-operation-name:
                   type: string
                   minLength: 6
                   description: >
                     'Name of the replacing operation
-                    update [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-c-*/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-c-*/layer-protocol=0/operation-client-interface-1-0:operation-client-interface-pac/operation-client-interface-configuration/operation-name]'
               example:
                 application-name: 'RegistryOffice'
-                application-release-number: '0.0.2'
+                application-release-number: '2.0.0'
                 old-operation-name: '/v1/register-application'
                 new-operation-name: '/v2/register-application'
       responses:
@@ -4405,7 +4405,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-0011/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-0011/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '401':
@@ -4450,17 +4450,17 @@ paths:
                     type: string
                     description: >
                       'Own application name
-                      from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
+                      from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]'
                   application-release-number:
                     type: string
                     description: >
                       'Own release number
-                      from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
+                      from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]'
                   application-purpose:
                     type: string
                     description: >
                       'Own application purpose
-                      from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-purpose]'
+                      from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-purpose]'
                   data-update-period:
                     type: string
                     enum:
@@ -4468,16 +4468,16 @@ paths:
                       - '1h-period'
                       - '24h-period'
                       - 'manual'
-                    description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/data-update-period]'
+                    description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/data-update-period]'
                   owner-name:
                     type: string
-                    description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/owner-name]'
+                    description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/owner-name]'
                   owner-email-address:
                     type: string
-                    description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/owner-email-address]'
+                    description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/owner-email-address]'
                 example:
                   application-name: 'OwnApplicationName'
-                  application-release-number: '0.0.1'
+                  application-release-number: '1.0.0'
                   application-purpose: 'Brief description of the purpose of the application.'
                   data-update-period: 'real-time'
                   owner-name: 'Thorsten Heinze'
@@ -4511,7 +4511,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-2001/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-2001/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '404':
@@ -4568,17 +4568,17 @@ paths:
                           type: string
                           description: >
                             'from either
-                            [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]
+                            [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-name]
                             or
-                            [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]
+                            [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-number]
                             or
-                            [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-purpose]
+                            [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/application-purpose]
                             or
-                            [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/data-update-period]
+                            [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/data-update-period]
                             or
-                            [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/owner-name]
+                            [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/owner-name]
                             or
-                            [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/owner-email-address]'
+                            [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/owner-email-address]'
                         datatype:
                           type: string
                           enum:
@@ -4588,7 +4588,7 @@ paths:
                         value: 'OwnApplicationName'
                         datatype: 'string'
                       - field-name: 'releaseNumber'
-                        value: '0.0.1'
+                        value: '1.0.0'
                         datatype: 'string'
                       - field-name: 'applicationPurpose'
                         value: 'Brief description of the purpose of the application.'
@@ -4616,12 +4616,12 @@ paths:
                           type: string
                           description: >
                             'Label that shall be presented on the button
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/label]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/label]'
                         request:
                           type: string
                           description: >
                             'Request that shall be called, when button gets pressed
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
                         input-value-list:
                           type: array
                           uniqueItems: true
@@ -4634,17 +4634,17 @@ paths:
                                 type: string
                                 description: >
                                   'Name of an input value required for executing the Request
-                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/name]'
+                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/name]'
                               unit:
                                 type: string
                                 description: >
                                   'Unit of an input value required for executing the Request
-                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/unit]'
+                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/unit]'
                         display-in-new-browser-window:
                           type: boolean
                           description: >
                             'True in case Request shall be represented in a new browser window
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/display-in-new-browser-window]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/display-in-new-browser-window]'
                     example:
                       - label: 'Release History'
                         request: 'https://10.118.125.157:1000/v1/inform-about-release-history-in-generic-representation'
@@ -4681,7 +4681,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-2002/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-2002/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '404':
@@ -4719,15 +4719,15 @@ paths:
                   properties:
                     release-number:
                       type: string
-                      description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/release-number]'
+                      description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/release-number]'
                     release-date:
                       type: string
-                      description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/release-date]'
+                      description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/release-date]'
                     changes:
                       type: string
-                      description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/changes]'
+                      description: 'from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/changes]'
                 example:
-                  - release-number: '0.0.1'
+                  - release-number: '1.0.0'
                     release-date: '20.11.2010'
                     changes: 'Initial version.'
           headers:
@@ -4759,7 +4759,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-2003/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-2003/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '404':
@@ -4804,19 +4804,19 @@ paths:
                         field-name:
                           type: string
                           description: >
-                            'from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/release-number]'
+                            'from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/release-number]'
                         value:
                           type: string
                           description: >
-                            'from [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/release-date]
+                            'from [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/release-date]
                              - 
-                            [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/changes]'
+                            [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-s-0000/layer-protocol=0/http-server-interface-1-0:http-server-interface-pac/http-server-interface-capability/release-list=*/changes]'
                         datatype:
                           type: string
                           enum:
                             - 'string'
                     example:
-                      - field-name: '0.0.1'
+                      - field-name: '1.0.0'
                         value: '20.11.2010 - Initial version.'
                         datatype: 'string'
                   consequent-action-list:
@@ -4833,12 +4833,12 @@ paths:
                           type: string
                           description: >
                             'Label that shall be presented on the button
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/label]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/label]'
                         request:
                           type: string
                           description: >
                             'Request that shall be called, when button gets pressed
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-configuration/request]'
                         input-value-list:
                           type: array
                           uniqueItems: true
@@ -4851,17 +4851,17 @@ paths:
                                 type: string
                                 description: >
                                   'Name of an input value required for executing the Request
-                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/name]'
+                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/name]'
                               unit:
                                 type: string
                                 description: >
                                   'Unit of an input value required for executing the Request
-                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/unit]'
+                                  from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/input-value-list=*/unit]'
                         display-in-new-browser-window:
                           type: boolean
                           description: >
                             'True in case Request shall be represented in a new browser window
-                            from [/core-model-1-4:control-construct/profile-collection/profile=*-0-0-1-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/display-in-new-browser-window]'
+                            from [/core-model-1-4:control-construct/profile-collection/profile=*-1-0-0-action-p-*/action-profile-1-0:action-profile-pac/action-profile-capability/display-in-new-browser-window]'
           headers:
             x-correlator:
               schema: 
@@ -4891,7 +4891,7 @@ paths:
                 example: 'EXPERIMENTAL'
               description: >
                   'Life cycle state of the consumed service
-                  find in [/core-model-1-4:control-construct/logical-termination-point=*-0-0-1-op-s-2004/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
+                  find in [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-op-s-2004/layer-protocol=0/operation-server-interface-1-0:operation-server-interface-pac/operation-server-interface-configuration/life-cycle-state]'
         '400':
           $ref: '#/components/responses/responseForErroredServiceRequests'
         '404':
@@ -4932,6 +4932,8 @@ paths:
                     properties:
                       uuid:
                         type: string
+                        pattern: '^([a-z]{2,6})-([0-9]+)-([0-9]+)-([0-9]+)$'
+                        example: 'ro-1-0-0'
                       profile-collection:
                         type: object
                         required:
@@ -4942,307 +4944,16 @@ paths:
                             uniqueItems: true
                             items:
                               anyOf:
-                                - description: 'admin profile'
+                                - description: 'action profile'
                                   type: object
                                   required:
                                     - uuid
                                     - profile-name
                                     # Bug in the postman mock server
                                     # original code is:
-                                    # - admin-profile-1-0:admin-profile-pac
+                                    # - action-profile-1-0:action-profile-pac
                                     # workaround code is:
                                     # - empty line -
-                                  properties:
-                                    uuid:
-                                      type: string
-                                    profile-name:
-                                      type: string
-                                      enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
-                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
-                                    admin-profile-1-0:admin-profile-pac:
-                                      type: object
-                                      required:
-                                        - admin-profile-capability
-                                        - admin-profile-configuration
-                                      properties:
-                                        admin-profile-capability:
-                                          type: object
-                                          required:
-                                            - administrator-name
-                                          properties:
-                                            administrator-name:
-                                              type: string
-                                        admin-profile-configuration:
-                                          type: object
-                                          required:
-                                            - user-name
-                                            - allowed-methods
-                                          properties:
-                                            user-name:
-                                              type: string
-                                            allowed-methods:
-                                              type: string
-                                              enum:
-                                                - 'admin-profile-1-0:ALLOWED_METHODS_TYPE_GET'
-                                                - 'admin-profile-1-0:ALLOWED_METHODS_TYPE_ALL'
-                                - description: 'string profile'
-                                  type: object
-                                  required:
-                                    - uuid
-                                    - profile-name
-                                    - string-profile-1-0:string-profile-pac
-                                  properties:
-                                    uuid:
-                                      type: string
-                                    profile-name:
-                                      type: string
-                                      enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
-                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
-                                    string-profile-1-0:string-profile-pac:
-                                      type: object
-                                      required:
-                                        - string-profile-capability
-                                        - string-profile-configuration
-                                      properties:
-                                        string-profile-capability:
-                                          type: object
-                                          required:
-                                            - string-name
-                                          properties:
-                                            string-name:
-                                              type: string
-                                        string-profile-configuration:
-                                          type: object
-                                          required:
-                                            - string-value
-                                          properties:
-                                            string-value:
-                                              type: string
-                                - description: 'integer profile'
-                                  type: object
-                                  required:
-                                    - uuid
-                                    - profile-name
-                                    - integer-profile-1-0:integer-profile-pac
-                                  properties:
-                                    uuid:
-                                      type: string
-                                    profile-name:
-                                      type: string
-                                      enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
-                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
-                                    integer-profile-1-0:integer-profile-pac:
-                                      type: object
-                                      required:
-                                        - integer-profile-capability
-                                        - integer-profile-configuration
-                                      properties:
-                                        integer-profile-capability:
-                                          type: object
-                                          required:
-                                            - integer-name
-                                          properties:
-                                            integer-name:
-                                              type: string
-                                            unit:
-                                              type: string
-                                            minimum:
-                                              type: integer
-                                            maximum:
-                                              type: integer
-                                        integer-profile-configuration:
-                                          type: object
-                                          required:
-                                            - integer-value
-                                          properties:
-                                            integer-value:
-                                              type: integer
-                                - description: 'application profile'
-                                  type: object
-                                  required:
-                                    - uuid
-                                    - profile-name
-                                    - application-profile-1-0:application-profile-pac
-                                  properties:
-                                    uuid:
-                                      type: string
-                                    profile-name:
-                                      type: string
-                                      enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
-                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
-                                    application-profile-1-0:application-profile-pac:
-                                      type: object
-                                      required:
-                                        - application-profile-capability
-                                        - application-profile-configuration
-                                      properties:
-                                        application-profile-capability:
-                                          type: object
-                                          required:
-                                            - application-name
-                                            - release-number
-                                          properties:
-                                            application-name:
-                                              type: string
-                                            release-number:
-                                              type: string
-                                        application-profile-configuration:
-                                          type: object
-                                          required:
-                                            - approval-status
-                                          properties:
-                                            approval-status:
-                                              type: string
-                                              enum:
-                                                - 'application-profile-1-0:APPROVAL_STATUS_TYPE_REGISTERED'
-                                                - 'application-profile-1-0:APPROVAL_STATUS_TYPE_APPROVED'
-                                                - 'application-profile-1-0:APPROVAL_STATUS_TYPE_BARRED'
-                                                - 'application-profile-1-0:APPROVAL_STATUS_TYPE_NOT_YET_DEFINED'
-                                - description: 'service record profile'
-                                  type: object
-                                  required:
-                                    - uuid
-                                    - profile-name
-                                    - service-record-profile-1-0:service-record-profile-pac
-                                  properties:
-                                    uuid:
-                                      type: string
-                                    profile-name:
-                                      type: string
-                                      enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
-                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
-                                    service-record-profile-1-0:service-record-profile-pac:
-                                      type: object
-                                      required:
-                                        - service-record-profile-capability
-                                      properties:
-                                        service-record-profile-capability:
-                                          type: object
-                                          required:
-                                            - x-correlator
-                                            - trace-indicator
-                                            - user
-                                            - originator
-                                            - application-name
-                                            - application-release-number
-                                            - operation-name
-                                            - response-code
-                                          properties:
-                                            x-correlator:
-                                              type: string
-                                            trace-indicator:
-                                              type: string
-                                            user:
-                                              type: string
-                                            originator:
-                                              type: string
-                                            application-name:
-                                              type: string
-                                            application-release-number:
-                                              type: string
-                                            operation-name:
-                                              type: string
-                                            response-code:
-                                              type: integer
-                                            timestamp:
-                                              type: string
-                                            stringified-body:
-                                              type: string
-                                            stringified-response:
-                                              type: string
-                                - description: 'oam record profile'
-                                  type: object
-                                  required:
-                                    - uuid
-                                    - profile-name
-                                    - oam-record-profile-1-0:oam-record-profile-pac
-                                  properties:
-                                    uuid:
-                                      type: string
-                                    profile-name:
-                                      type: string
-                                      enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
-                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
-                                    oam-record-profile-1-0:oam-record-profile-pac:
-                                      type: object
-                                      required:
-                                        - oam-record-profile-capability
-                                      properties:
-                                        oam-record-profile-capability:
-                                          type: object
-                                          required:
-                                            - application-name
-                                            - release-number
-                                            - method
-                                            - resource
-                                            - stringified-body
-                                            - response-code
-                                            - user-name
-                                            - timestamp
-                                          properties:
-                                            application-name:
-                                              type: string
-                                            release-number:
-                                              type: string
-                                            method:
-                                              type: string
-                                              enum:
-                                                - 'oam-record-profile-1-0:METHOD_TYPE_GET'
-                                                - 'oam-record-profile-1-0:METHOD_TYPE_PUT'
-                                                - 'oam-record-profile-1-0:METHOD_TYPE_CREATE'
-                                                - 'oam-record-profile-1-0:METHOD_TYPE_DELETE'
-                                            resource:
-                                              type: string
-                                            stringified-body:
-                                              type: string
-                                            response-code:
-                                              type: integer
-                                            user-name:
-                                              type: string
-                                            timestamp:
-                                              type: string
-                                - description: 'action profile'
-                                  type: object
-                                  required:
-                                    - uuid
-                                    - profile-name
-                                    - action-profile-1-0:action-profile-pac
                                   properties:
                                     uuid:
                                       type: string
@@ -5293,8 +5004,92 @@ paths:
                                           properties:
                                             request:
                                               type: string
+                                - description: 'integer profile'
+                                  type: object
+                                  required:
+                                    - uuid
+                                    - profile-name
+                                    - integer-profile-1-0:integer-profile-pac
+                                  properties:
+                                    uuid:
+                                      type: string
+                                    profile-name:
+                                      type: string
+                                      enum:
+                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
+                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
+                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
+                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
+                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
+                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                    integer-profile-1-0:integer-profile-pac:
+                                      type: object
+                                      required:
+                                        - integer-profile-capability
+                                        - integer-profile-configuration
+                                      properties:
+                                        integer-profile-capability:
+                                          type: object
+                                          required:
+                                            - integer-name
+                                          properties:
+                                            integer-name:
+                                              type: string
+                                            unit:
+                                              type: string
+                                            minimum:
+                                              type: integer
+                                            maximum:
+                                              type: integer
+                                        integer-profile-configuration:
+                                          type: object
+                                          required:
+                                            - integer-value
+                                          properties:
+                                            integer-value:
+                                              type: integer
+                                - description: 'string profile'
+                                  type: object
+                                  required:
+                                    - uuid
+                                    - profile-name
+                                    - string-profile-1-0:string-profile-pac
+                                  properties:
+                                    uuid:
+                                      type: string
+                                    profile-name:
+                                      type: string
+                                      enum:
+                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
+                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
+                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
+                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
+                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
+                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                    string-profile-1-0:string-profile-pac:
+                                      type: object
+                                      required:
+                                        - string-profile-capability
+                                        - string-profile-configuration
+                                      properties:
+                                        string-profile-capability:
+                                          type: object
+                                          required:
+                                            - string-name
+                                          properties:
+                                            string-name:
+                                              type: string
+                                        string-profile-configuration:
+                                          type: object
+                                          required:
+                                            - string-value
+                                          properties:
+                                            string-value:
+                                              type: string
                             example:
-                              - uuid: '*-0-0-1-integer-p-0000'
+                              - uuid: 'ro-1-0-0-integer-p-1000'
                                 profile-name: 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
                                 integer-profile-1-0:integer-profile-pac:
                                   integer-profile-capability:
@@ -5304,14 +5099,6 @@ paths:
                                     maximum: 1000000
                                   integer-profile-configuration:
                                     integer-value: 1000000
-                              - uuid: '*-0-0-1-application-p-0000'
-                                profile-name: 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                application-profile-1-0:application-profile-pac:
-                                  application-profile-capability:
-                                    application-name: 'RegistryOffice'
-                                    release-number: '0.0.1'
-                                  application-profile-configuration:
-                                    approval-status: 'application-profile-1-0:APPROVAL_STATUS_TYPE_APPROVED'
                       logical-termination-point:
                         type: array
                         uniqueItems: true
@@ -5646,10 +5433,10 @@ paths:
                                               remote-port:
                                                 type: integer
                         example:
-                          - uuid: '*-0-0-1-op-c-0020'
+                          - uuid: 'ro-1-0-0-op-c-0020'
                             ltp-direction: 'core-model-1-4:TERMINATION_DIRECTION_SINK'
                             client-ltp: []
-                            server-ltp: ['*-0-0-1-http-c-0020']
+                            server-ltp: ['ro-1-0-0-http-c-0020']
                             layer-protocol:
                               - local-id: '0'
                                 layer-protocol-name: 'operation-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_OPERATION_LAYER'
@@ -5660,10 +5447,10 @@ paths:
                                   operation-client-interface-status:
                                     operational-state: 'operation-client-interface-1-0:OPERATIONAL_STATE_TYPE_NOT_YET_DEFINED'
                                     life-cycle-state: 'operation-client-interface-1-0:LIFE_CYCLE_STATE_TYPE_NOT_YET_DEFINED'
-                          - uuid: '*-0-0-1-http-c-0020'
+                          - uuid: 'ro-1-0-0-http-c-0020'
                             ltp-direction: 'core-model-1-4:TERMINATION_DIRECTION_SINK'
-                            client-ltp: ['*-0-0-1-op-c-0020']
-                            server-ltp: ['*-0-0-1-tcp-c-0020']
+                            client-ltp: ['ro-1-0-0-op-c-0020']
+                            server-ltp: ['ro-1-0-0-tcp-c-0020']
                             layer-protocol:
                               - local-id: '0'
                                 layer-protocol-name: 'http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER'
@@ -5671,7 +5458,7 @@ paths:
                                   http-client-interface-capability:
                                     application-name: 'RegistryOffice'
                                   http-client-interface-configuration:
-                                    release-number: '0.0.1'
+                                    release-number: '1.0.0'
                       forwarding-domain:
                         type: array
                         minItems: 1
@@ -5727,9 +5514,9 @@ paths:
                                         logical-termination-point:
                                           type: string
                         example:
-                          - uuid: '*-0-0-1-op-fd-0000'
+                          - uuid: 'ro-1-0-0-op-fd-0000'
                             forwarding-construct:
-                              - uuid: '*-0-0-1-op-fc-0003'
+                              - uuid: 'ro-1-0-0-op-fc-0003'
                                 name:
                                   - value-name: 'ForwardingKind'
                                     value: 'core-model-1-4:FORWARDING_KIND_TYPE_INVARIANT_PROCESS_SNIPPET'
@@ -5738,11 +5525,11 @@ paths:
                                 fc-port:
                                   - local-id: '000'
                                     port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_MANAGEMENT'
-                                    logical-termination-point: '*-0-0-1-op-s-0003'
+                                    logical-termination-point: 'ro-1-0-0-op-s-0003'
                                   - local-id: '200'
                                     port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_OUTPUT'
-                                    logical-termination-point: '*-0-0-1-op-c-0050'
-                              - uuid: '*-0-0-1-op-fc-0004'
+                                    logical-termination-point: 'ro-1-0-0-op-c-0050'
+                              - uuid: 'ro-1-0-0-op-fc-0004'
                                 name:
                                   - value-name: 'ForwardingKind'
                                     value: 'core-model-1-4:FORWARDING_KIND_TYPE_INVARIANT_PROCESS_SNIPPET'
@@ -5751,10 +5538,10 @@ paths:
                                 fc-port:
                                   - local-id: '000'
                                     port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_MANAGEMENT'
-                                    logical-termination-point: '*-0-0-1-op-s-0005'
+                                    logical-termination-point: 'ro-1-0-0-op-s-0005'
                                   - local-id: '200'
                                     port-direction: 'core-model-1-4:PORT_DIRECTION_TYPE_OUTPUT'
-                                    logical-termination-point: '*-0-0-1-op-c-0060'
+                                    logical-termination-point: 'ro-1-0-0-op-c-0060'
         '400':
           $ref: '#/components/responses/responseForErroredOamRequests'
         '401':
@@ -5768,161 +5555,187 @@ paths:
         default:
           $ref: '#/components/responses/responseForErroredOamRequests'
 
-  /core-model-1-4:control-construct/profile-collection/profile={uuid}/application-profile-1-0:application-profile-pac/application-profile-capability/application-name:
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}:
     parameters:
       - in: path
         name: uuid
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-application-p-\d{4}$'
-          example: '*-0-0-1-application-p-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-([a-z]+)-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-action-p-1000'
     get:
-      operationId: getApplicationProfileApplicationName
-      summary: 'Returns the name of the application'
+      operationId: getProfileInstance
+      summary: 'Returns entire instance of Profile'
       tags:
-        - ApplicationProfile
+        - Core
       security:
         - basicAuth: []
       responses:
         '200':
-          description: 'Application name provided'
+          description: 'Instance of Profile provided'
           content:
             application/json:
               schema:
                 type: object
                 required:
-                  - application-profile-1-0:application-name
+                  - core-model-1-4:profile
                 properties:
-                  application-profile-1-0:application-name:
-                    type: string
-                    example: 'RegistryOffice'
-        '400':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '401':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '403':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '404':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '500':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        default:
-          $ref: '#/components/responses/responseForErroredOamRequests'
-  /core-model-1-4:control-construct/profile-collection/profile={uuid}/application-profile-1-0:application-profile-pac/application-profile-capability/release-number:
-    parameters:
-      - in: path
-        name: uuid
-        required: true
-        schema:
-          type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-application-p-\d{4}$'
-          example: '*-0-0-1-application-p-0000'
-    get:
-      operationId: getApplicationProfileReleaseNumber
-      summary: 'Returns the release number of the application'
-      tags:
-        - ApplicationProfile
-      security:
-        - basicAuth: []
-      responses:
-        '200':
-          description: 'Release number provided'
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - application-profile-1-0:release-number
-                properties:
-                  application-profile-1-0:release-number:
-                    type: string
-                    example: '0.0.1'
-        '400':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '401':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '403':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '404':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '500':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        default:
-          $ref: '#/components/responses/responseForErroredOamRequests'
-  /core-model-1-4:control-construct/profile-collection/profile={uuid}/application-profile-1-0:application-profile-pac/application-profile-configuration/approval-status:
-    parameters:
-      - in: path
-        name: uuid
-        required: true
-        schema:
-          type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-application-p-\d{4}$'
-          example: '*-0-0-1-application-p-0000'
-    get:
-      operationId: getApplicationProfileApprovalStatus
-      summary: 'Returns the configured value of the approval status'
-      tags:
-        - ApplicationProfile
-      security:
-        - basicAuth: []
-      responses:
-        '200':
-          description: 'Approval status provided'
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - application-profile-1-0:approval-status
-                properties:
-                  application-profile-1-0:approval-status:
-                    type: string
-                    enum:
-                      - 'application-profile-1-0:APPROVAL_STATUS_TYPE_REGISTERED'
-                      - 'application-profile-1-0:APPROVAL_STATUS_TYPE_APPROVED'
-                      - 'application-profile-1-0:APPROVAL_STATUS_TYPE_BARRED'
-                      - 'application-profile-1-0:APPROVAL_STATUS_TYPE_NOT_YET_DEFINED'
-                    example: 'application-profile-1-0:APPROVAL_STATUS_TYPE_APPROVED'
-        '400':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '401':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '403':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '404':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        '500':
-          $ref: '#/components/responses/responseForErroredOamRequests'
-        default:
-          $ref: '#/components/responses/responseForErroredOamRequests'
-    put:
-      operationId: putApplicationProfileApprovalStatus
-      summary: 'Configures the approval status'
-      tags:
-        - ApplicationProfile
-      security:
-        - basicAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - application-profile-1-0:approval-status
-              properties:
-                application-profile-1-0:approval-status:
-                  type: string
-                  enum:
-                    - 'application-profile-1-0:APPROVAL_STATUS_TYPE_REGISTERED'
-                    - 'application-profile-1-0:APPROVAL_STATUS_TYPE_APPROVED'
-                    - 'application-profile-1-0:APPROVAL_STATUS_TYPE_BARRED'
-                    - 'application-profile-1-0:APPROVAL_STATUS_TYPE_NOT_YET_DEFINED'
-                  example: 'application-profile-1-0:APPROVAL_STATUS_TYPE_APPROVED'
-      responses:
-        '204':
-          description: 'Application status configured'
+                  core-model-1-4:profile:
+                    oneOf:
+                      - description: 'action profile'
+                        type: object
+                        required:
+                          - core-model-1-4:uuid
+                          - core-model-1-4:profile-name
+                          - action-profile-1-0:action-profile-pac
+                        properties:
+                          core-model-1-4:uuid:
+                            type: string
+                          core-model-1-4:profile-name:
+                            type: string
+                            enum:
+                              - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                              - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                              - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
+                          action-profile-1-0:action-profile-pac:
+                            type: object
+                            required:
+                              - action-profile-capability
+                              - action-profile-configuration
+                            properties:
+                              action-profile-capability:
+                                type: object
+                                required:
+                                  - operation-name
+                                  - label
+                                  - new-browser-window
+                                properties:
+                                  operation-name:
+                                    type: string
+                                  label:
+                                    type: string
+                                  input-value-list:
+                                    type: array
+                                    items:
+                                      type: object
+                                      required:
+                                        - field-name
+                                      properties:
+                                        field-name:
+                                          type: string
+                                        unit:
+                                          type: string
+                                  display-in-new-browser-window:
+                                    type: boolean
+                              action-profile-configuration:
+                                type: object
+                                required:
+                                  - request
+                                properties:
+                                  request:
+                                    type: string
+                      - description: 'integer profile'
+                        type: object
+                        required:
+                          - core-model-1-4:uuid
+                          - core-model-1-4:profile-name
+                          - integer-profile-1-0:integer-profile-pac
+                        properties:
+                          core-model-1-4:uuid:
+                            type: string
+                          core-model-1-4:profile-name:
+                            type: string
+                            enum:
+                              - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                              - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                              - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
+                          integer-profile-1-0:integer-profile-pac:
+                            type: object
+                            required:
+                              - integer-profile-capability
+                              - integer-profile-configuration
+                            properties:
+                              integer-profile-capability:
+                                type: object
+                                required:
+                                  - integer-name
+                                properties:
+                                  integer-name:
+                                    type: string
+                                  unit:
+                                    type: string
+                                  minimum:
+                                    type: integer
+                                  maximum:
+                                    type: integer
+                              integer-profile-configuration:
+                                type: object
+                                required:
+                                  - integer-value
+                                properties:
+                                  integer-value:
+                                    type: integer
+                      - description: 'string profile'
+                        type: object
+                        required:
+                          - core-model-1-4:uuid
+                          - core-model-1-4:profile-name
+                          - string-profile-1-0:string-profile-pac
+                        properties:
+                          core-model-1-4:uuid:
+                            type: string
+                          core-model-1-4:profile-name:
+                            type: string
+                            enum:
+                              - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                              - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                              - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
+                          string-profile-1-0:string-profile-pac:
+                            type: object
+                            required:
+                              - string-profile-capability
+                              - string-profile-configuration
+                            properties:
+                              string-profile-capability:
+                                type: object
+                                required:
+                                  - string-name
+                                properties:
+                                  string-name:
+                                    type: string
+                              string-profile-configuration:
+                                type: object
+                                required:
+                                  - string-value
+                                properties:
+                                  string-value:
+                                    type: string
+              example:
+              - core-model-1-4:profile:
+                  uuid: 'ro-1-0-0-action-p-1000'
+                  profile-name: 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                  action-profile-1-0:action-profile-pac:
+                    action-profile-capability:
+                      operation-name: '/v1/start-application-in-generic-representation'
+                      label: 'Inform about Application'
+                      input-value-list:
+                        - field-name: 'Label of input field'
+                          unit: 'Unit at input field'
+                      display-in-new-browser-window: false
+                    action-profile-configuration:
+                      request: 'https://10.118.125.157:1000/v1/inform-about-application-in-generic-representation'
+              - core-model-1-4:profile:
+                  uuid: 'ro-1-0-0-integer-p-1000'
+                  profile-name: 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                  integer-profile-1-0:integer-profile-pac:
+                    integer-profile-capability:
+                      integer-name: 'maximumNumberOfEntries'
+                      unit: 'records'
+                      minimum: 0
+                      maximum: 1000000
+                    integer-profile-configuration:
+                      integer-value: 1000000
         '400':
           $ref: '#/components/responses/responseForErroredOamRequests'
         '401':
@@ -5943,8 +5756,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-integer-p-\d{4}$'
-          example: '*-0-0-1-integer-p-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-integer-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-integer-p-1000'
     get:
       operationId: getIntegerProfileIntegerName
       summary: 'Returns the name of the Integer'
@@ -5984,8 +5797,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-integer-p-\d{4}$'
-          example: '*-0-0-1-integer-p-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-integer-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-integer-p-1000'
     get:
       operationId: getIntegerProfileUnit
       summary: 'Returns the unit of the Integer'
@@ -6025,8 +5838,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-integer-p-\d{4}$'
-          example: '*-0-0-1-integer-p-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-integer-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-integer-p-1000'
     get:
       operationId: getIntegerProfileMinimum
       summary: 'Returns the minimum value of the Integer'
@@ -6066,8 +5879,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-integer-p-\d{4}$'
-          example: '*-0-0-1-integer-p-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-integer-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-integer-p-1000'
     get:
       operationId: getIntegerProfileMaximum
       summary: 'Returns the maximum value of the Integer'
@@ -6107,8 +5920,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-integer-p-\d{4}$'
-          example: '*-0-0-1-integer-p-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-integer-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-integer-p-1000'
     get:
       operationId: getIntegerProfileIntegerValue
       summary: 'Returns the configured value of the Integer'
@@ -6186,8 +5999,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
-          example: '*-0-0-1-action-p-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-action-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-action-p-1000'
     get:
       operationId: getActionProfileOperationName
       summary: 'Returns the name of the Operation'
@@ -6227,8 +6040,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
-          example: '*-action-p-1000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-action-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-action-p-1000'
     get:
       operationId: getActionProfileLabel
       summary: 'Returns the Label of the Action'
@@ -6268,8 +6081,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
-          example: '*-action-p-1000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-action-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-action-p-1000'
     get:
       operationId: getActionProfileInputValueListt
       summary: 'Returns the list of input values'
@@ -6320,8 +6133,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
-          example: '*-action-p-1000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-action-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-action-p-1000'
     get:
       operationId: getActionProfileDisplayInNewBrowserWindow
       summary: 'Returns whether to be presented in new browser window'
@@ -6361,8 +6174,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z]{2,6}-([0-9]+)-([0-9]+)-([0-9]+)-action-p-10[0-9]{2}$'
-          example: '*-action-p-1000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-action-p-10([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-action-p-1000'
     get:
       operationId: getActionProfileRequest
       summary: 'Returns the configured path of the Request'
@@ -6438,8 +6251,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-op-s-\d{4}$'
-          example: '*-0-0-1-op-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-s-([0-3])0([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-op-s-0000'
     get:
       operationId: getOperationServerOperationName
       summary: 'Returns operation name'
@@ -6479,8 +6292,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-op-s-\d{4}$'
-          example: '*-0-0-1-op-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-s-([0-3])0([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-op-s-0000'
     get:
       operationId: getOperationServerLifeCycleState
       summary: 'Returns the configured life cycle state of the operation'
@@ -6568,8 +6381,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-op-s-\d{4}$'
-          example: '*-0-0-1-op-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-s-([0-3])0([0-9,a-f]{2})$'
+          example: 'ro-1-0-0-op-s-0000'
     get:
       operationId: getOperationServerOperationKey
       summary: 'Returns key for connecting'
@@ -6645,8 +6458,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-s-\d{4}$'
-          example: '*-0-0-1-http-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-s-0000$'
+          example: 'ro-1-0-0-http-s-0000'
     get:
       operationId: getHttpServerApplicationName
       summary: 'Returns application name'
@@ -6686,8 +6499,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-s-\d{4}$'
-          example: '*-0-0-1-http-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-s-0000$'
+          example: 'ro-1-0-0-http-s-0000'
     get:
       operationId: getHttpServerReleaseNumber
       summary: 'Returns release number'
@@ -6707,7 +6520,7 @@ paths:
                 properties:
                   http-server-interface-1-0:release-number:
                     type: string
-                    example: '0.0.1'
+                    example: '1.0.0'
         '400':
           $ref: '#/components/responses/responseForErroredOamRequests'
         '401':
@@ -6727,8 +6540,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-s-\d{4}$'
-          example: '*-0-0-1-http-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-s-0000$'
+          example: 'ro-1-0-0-http-s-0000'
     get:
       operationId: getHttpServerApplicationPurpose
       summary: 'Returns application purpose'
@@ -6768,8 +6581,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-s-\d{4}$'
-          example: '*-0-0-1-http-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-s-0000$'
+          example: 'ro-1-0-0-http-s-0000'
     get:
       operationId: getHttpServerDataUpdatePeriode
       summary: 'Returns update period'
@@ -6814,8 +6627,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-s-\d{4}$'
-          example: '*-0-0-1-http-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-s-0000$'
+          example: 'ro-1-0-0-http-s-0000'
     get:
       operationId: getHttpServerOwnerName
       summary: 'Returns owner name'
@@ -6855,8 +6668,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-s-\d{4}$'
-          example: '*-0-0-1-http-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-s-0000$'
+          example: 'ro-1-0-0-http-s-0000'
     get:
       operationId: getHttpServerOwnerEmailAddress
       summary: 'Returns owner email address'
@@ -6896,8 +6709,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-s-\d{4}$'
-          example: '*-0-0-1-http-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-s-0000$'
+          example: 'ro-1-0-0-http-s-0000'
     get:
       operationId: getHttpServerReleaseList
       summary: 'Returns list of releases'
@@ -6932,7 +6745,7 @@ paths:
                         changes:
                           type: string
                     example:
-                      - release-number: '0.0.1'
+                      - release-number: '1.0.0'
                         release-date: '20.11.2010'
                         changes: 'Initial version.'
         '400':
@@ -6955,8 +6768,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-tcp-s-\d{4}$'
-          example: '*-0-0-1-tcp-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-tcp-s-0000$'
+          example: 'ro-1-0-0-tcp-s-0000'
     get:
       operationId: getTcpServerLocalAddress
       summary: 'Returns address of the server'
@@ -7048,8 +6861,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-tcp-s-\d{4}$'
-          example: '*-0-0-1-tcp-s-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-tcp-s-0000$'
+          example: 'ro-1-0-0-tcp-s-0000'
     get:
       operationId: getTcpServerLocalPort
       summary: 'Returns TCP port of the server'
@@ -7126,8 +6939,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-op-c-\d{4}$'
-          example: '*-0-0-1-op-c-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([0-3])([0-9,a-f]{3})$'
+          example: 'ro-1-0-0-op-c-0000'
     get:
       operationId: getOperationClientOperationName
       summary: 'Returns operation name'
@@ -7202,8 +7015,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-op-c-\d{4}$'
-          example: '*-0-0-1-op-c-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([0-3])([0-9,a-f]{3})$'
+          example: 'ro-1-0-0-op-c-0000'
     get:
       operationId: getOperationClientOperationKey
       summary: 'Returns key used for connecting to server.'
@@ -7278,8 +7091,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-op-c-\d{4}$'
-          example: '*-0-0-1-op-c-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([0-3])([0-9,a-f]{3})$'
+          example: 'ro-1-0-0-op-c-0000'
     get:
       operationId: getOperationClientOperationalState
       summary: 'Returns operational state of the operation'
@@ -7323,8 +7136,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-op-c-\d{4}$'
-          example: '*-0-0-1-op-c-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([0-3])([0-9,a-f]{3})$'
+          example: 'ro-1-0-0-op-c-0000'
     get:
       operationId: getOperationClientLifeCycleState
       summary: 'Returns life cycle state of the operation'
@@ -7371,8 +7184,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-op-c-0040'
-          example: '*-0-0-1-op-c-0040'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-0040$'
+          example: 'ro-1-0-0-op-c-0040'
     get:
       operationId: getOperationClientDetailedLoggingIsOn
       summary: 'Returns detailed logging configuration.'
@@ -7447,8 +7260,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-c-\d{4}$'
-          example: '*-0-0-1-http-c-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-c-([0-3])([0-9,a-f]{2})0$'
+          example: 'ro-1-0-0-http-c-0000'
     get:
       operationId: getHttpClientApplicationName
       summary: 'Returns name of application to be addressed'
@@ -7488,8 +7301,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-http-c-\d{4}$'
-          example: '*-0-0-1-http-c-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-http-c-([0-3])([0-9,a-f]{2})0$'
+          example: 'ro-1-0-0-http-c-0000'
     get:
       operationId: getHttpClientReleaseNumber
       summary: 'Returns release number of application to be addressed'
@@ -7509,7 +7322,7 @@ paths:
                 properties:
                   http-client-interface-1-0:release-number:
                     type: string
-                    example: '0.0.1'
+                    example: '1.0.0'
         '400':
           $ref: '#/components/responses/responseForErroredOamRequests'
         '401':
@@ -7540,8 +7353,8 @@ paths:
                 properties:
                   http-client-interface-1-0:release-number:
                     type: string
-                    pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$'
-                    example: '0.0.1'
+                    pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
+                    example: '1.0.0'
       responses:
         '204':
           description: 'Release number configured'
@@ -7565,8 +7378,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-tcp-c-\d{4}$'
-          example: '*-0-0-1-tcp-c-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-tcp-c-([0-3])([0-9,a-f]{2})0$'
+          example: 'ro-1-0-0-tcp-c-0000'
     get:
       operationId: getTcpClientRemoteAddress
       summary: 'Returns remote address'
@@ -7670,8 +7483,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^[a-z,*]+-\d+-\d+-\d+-tcp-c-\d{4}$'
-          example: '*-0-0-1-tcp-c-0000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-tcp-c-([0-3])([0-9,a-f]{2})0$'
+          example: 'ro-1-0-0-tcp-c-0000'
     get:
       operationId: getTcpClientRemotePort
       summary: 'Returns target TCP port at server'


### PR DESCRIPTION
- Resource references changed from "-0-0-1-" to "-1-0-0-" in descriptions.
- Release numbers changed from 0.0.1 to 1.0.0.
- UUID patterns harmonized and adapted to hexadecimal counting.
- '*' removed from examples of UUIDs
- Profiles, which are application data, removed
- New path added : /core-model-1-4:control-construct/profile-collection/profile={uuid}