### PR TITLE
Fixed setting property on undefined

### DIFF
--- a/server/basicServices/basicServices/services/PrepareALTForwardingAutomation.js
+++ b/server/basicServices/basicServices/services/PrepareALTForwardingAutomation.js
@@ -263,7 +263,7 @@ function getUnconfigurableHttpClientForwardingAutomationInputAsync(httpClientCon
             let forwardingAutomation;
             let serviceRequestCausesLtpDeletionRequestForwardingName = "ServiceRequestCausesLtpDeletionRequest";
             let serviceRequestCausesLtpDeletionRequestContext;
-            let serviceRequestCausesLtpDeletionRequestRequestBody;
+            let serviceRequestCausesLtpDeletionRequestRequestBody = {};
 
             if (httpClientConfigurationStatus) {
                 if (httpClientConfigurationStatus.updated) {
@@ -318,7 +318,7 @@ function getUnconfigurableTcpClientForwardingAutomationInputAsync(tcpClientConfi
             let forwardingAutomation;
             let serviceRequestCausesLtpDeletionRequestForwardingName = "ServiceRequestCausesLtpDeletionRequest";
             let serviceRequestCausesLtpDeletionRequestContext;
-            let serviceRequestCausesLtpDeletionRequestRequestBody;
+            let serviceRequestCausesLtpDeletionRequestRequestBody = {};
 
             if (tcpClientConfigurationStatus) {
                 if (tcpClientConfigurationStatus.updated) {
@@ -382,7 +382,7 @@ function getUnconfigurableOperationClientForwardingAutomationInputListAsync(oper
             let forwardingAutomation;
             let serviceRequestCausesLtpDeletionRequestForwardingName = "ServiceRequestCausesLtpDeletionRequest";
             let serviceRequestCausesLtpDeletionRequestContext;
-            let serviceRequestCausesLtpDeletionRequestRequestBody;
+            let serviceRequestCausesLtpDeletionRequestRequestBody = {};
 
             if (operationClientConfigurationStatusList) {
                 for (let i = 0; i < operationClientConfigurationStatusList.length; i++) {

--- a/server/basicServices/basicServices/services/PrepareALTForwardingAutomation.js
+++ b/server/basicServices/basicServices/services/PrepareALTForwardingAutomation.js
@@ -382,14 +382,15 @@ function getUnconfigurableOperationClientForwardingAutomationInputListAsync(oper
             let forwardingAutomation;
             let serviceRequestCausesLtpDeletionRequestForwardingName = "ServiceRequestCausesLtpDeletionRequest";
             let serviceRequestCausesLtpDeletionRequestContext;
-            let serviceRequestCausesLtpDeletionRequestRequestBody = {};
 
             if (operationClientConfigurationStatusList) {
                 for (let i = 0; i < operationClientConfigurationStatusList.length; i++) {
                     let operationClientConfigurationStatus = operationClientConfigurationStatusList[i];
                     if (operationClientConfigurationStatus.updated) {
                         let operationClientUuid = operationClientConfigurationStatus.uuid;
-                        serviceRequestCausesLtpDeletionRequestRequestBody.uuid = operationClientUuid;
+                        let serviceRequestCausesLtpDeletionRequestRequestBody = {
+                            uuid: operationClientUuid
+                        }
                         serviceRequestCausesLtpDeletionRequestRequestBody = onfFormatter
                                         .modifyJsonObjectKeysToKebabCase(serviceRequestCausesLtpDeletionRequestRequestBody)
                         forwardingAutomation = new forwardingConstructAutomationInput(


### PR DESCRIPTION
Exception has occurred: TypeError: Cannot set properties of undefined (setting 'uuid')
That happend because object has not been initialized before it was used.

Fixes #260

Signed-off-by: Martin Sunal <martin.sunal@paxet.io>