### PR TITLE
Remove artifacts of obsolete Profiles (Fixes #289)

### DIFF
--- a/ApplicationPattern.yaml
+++ b/ApplicationPattern.yaml
@@ -5065,6 +5065,7 @@ paths:
                                       type: string
                                       enum:
                                         - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                        - 'file-profile-1-0:PROFILE_NAME_TYPE_FILE_PROFILE'
                                         - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
                                         - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                                     action-profile-1-0:action-profile-pac:
@@ -5078,7 +5079,7 @@ paths:
                                           required:
                                             - operation-name
                                             - label
-                                            - new-browser-window
+                                            - display-in-new-browser-window
                                           properties:
                                             operation-name:
                                               type: string
@@ -5104,6 +5105,56 @@ paths:
                                           properties:
                                             request:
                                               type: string
+                                - description: 'file profile'
+                                  type: object
+                                  required:
+                                    - uuid
+                                    - profile-name
+                                    - file-profile-1-0:file-profile-pac
+                                  properties:
+                                    uuid:
+                                      type: string
+                                    profile-name:
+                                      type: string
+                                      enum:
+                                        - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                        - 'file-profile-1-0:PROFILE_NAME_TYPE_FILE_PROFILE'
+                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
+                                    file-profile-1-0:file-profile-pac:
+                                      type: object
+                                      required:
+                                        - file-profile-capability
+                                        - file-profile-configuration
+                                      properties:
+                                        file-profile-capability:
+                                          type: object
+                                          required:
+                                            - file-identifier
+                                            - file-description
+                                          properties:
+                                            file-identifier:
+                                              type: string
+                                            file-description:
+                                              type: string
+                                        file-profile-configuration:
+                                          type: object
+                                          required:
+                                            - file-path
+                                          properties:
+                                            file-path:
+                                              type: string
+                                            user-name:
+                                              type: string
+                                            password:
+                                              type: string
+                                            operation:
+                                              type: string
+                                              enum:
+                                              - 'file-profile-1-0:OPERATION_TYPE_READ_ONLY'
+                                              - 'file-profile-1-0:OPERATION_TYPE_READ_WRITE'
+                                              - 'file-profile-1-0:OPERATION_TYPE_OFF'
+                                              - 'file-profile-1-0:OPERATION_TYPE_NOT_YET_DEFINED'
                                 - description: 'integer profile'
                                   type: object
                                   required:
@@ -5117,6 +5168,7 @@ paths:
                                       type: string
                                       enum:
                                         - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                        - 'file-profile-1-0:PROFILE_NAME_TYPE_FILE_PROFILE'
                                         - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
                                         - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                                     integer-profile-1-0:integer-profile-pac:
@@ -5158,6 +5210,7 @@ paths:
                                       type: string
                                       enum:
                                         - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                        - 'file-profile-1-0:PROFILE_NAME_TYPE_FILE_PROFILE'
                                         - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
                                         - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                                     string-profile-1-0:string-profile-pac:
@@ -6021,7 +6074,7 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-([a-z]+)-p-10([0-9,a-f]{2})$'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-([a-z]+)-p-([0-9,a-f]{3})$'
           example: 'ro-1-0-0-action-p-000'
     get:
       operationId: getProfileInstance
@@ -6045,16 +6098,17 @@ paths:
                       - description: 'action profile'
                         type: object
                         required:
-                          - core-model-1-4:uuid
-                          - core-model-1-4:profile-name
+                          - uuid
+                          - profile-name
                           - action-profile-1-0:action-profile-pac
                         properties:
-                          core-model-1-4:uuid:
+                          uuid:
                             type: string
-                          core-model-1-4:profile-name:
+                          profile-name:
                             type: string
                             enum:
                               - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                              - 'file-profile-1-0:PROFILE_NAME_TYPE_FILE_PROFILE'
                               - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
                               - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                           action-profile-1-0:action-profile-pac:
@@ -6068,7 +6122,7 @@ paths:
                                 required:
                                   - operation-name
                                   - label
-                                  - new-browser-window
+                                  - display-in-new-browser-window
                                 properties:
                                   operation-name:
                                     type: string
@@ -6094,19 +6148,70 @@ paths:
                                 properties:
                                   request:
                                     type: string
-                      - description: 'integer profile'
+                      - description: 'file profile'
                         type: object
                         required:
-                          - core-model-1-4:uuid
-                          - core-model-1-4:profile-name
-                          - integer-profile-1-0:integer-profile-pac
+                          - uuid
+                          - profile-name
+                          - file-profile-1-0:file-profile-pac
                         properties:
-                          core-model-1-4:uuid:
+                          uuid:
                             type: string
-                          core-model-1-4:profile-name:
+                          profile-name:
                             type: string
                             enum:
                               - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                              - 'file-profile-1-0:PROFILE_NAME_TYPE_FILE_PROFILE'
+                              - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                              - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
+                          file-profile-1-0:file-profile-pac:
+                            type: object
+                            required:
+                              - file-profile-capability
+                              - file-profile-configuration
+                            properties:
+                              file-profile-capability:
+                                type: object
+                                required:
+                                  - file-identifier
+                                  - file-description
+                                properties:
+                                  file-identifier:
+                                    type: string
+                                  file-description:
+                                    type: string
+                              file-profile-configuration:
+                                type: object
+                                required:
+                                  - file-path
+                                properties:
+                                  file-path:
+                                    type: string
+                                  user-name:
+                                    type: string
+                                  password:
+                                    type: string
+                                  operation:
+                                    type: string
+                                    enum:
+                                      - 'file-profile-1-0:OPERATION_TYPE_READ_ONLY'
+                                      - 'file-profile-1-0:OPERATION_TYPE_READ_WRITE'
+                                      - 'file-profile-1-0:OPERATION_TYPE_OFF'
+                                      - 'file-profile-1-0:OPERATION_TYPE_NOT_YET_DEFINED'
+                      - description: 'integer profile'
+                        type: object
+                        required:
+                          - uuid
+                          - profile-name
+                          - integer-profile-1-0:integer-profile-pac
+                        properties:
+                          uuid:
+                            type: string
+                          profile-name:
+                            type: string
+                            enum:
+                              - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                              - 'file-profile-1-0:PROFILE_NAME_TYPE_FILE_PROFILE'
                               - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
                               - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                           integer-profile-1-0:integer-profile-pac:
@@ -6138,16 +6243,17 @@ paths:
                       - description: 'string profile'
                         type: object
                         required:
-                          - core-model-1-4:uuid
-                          - core-model-1-4:profile-name
+                          - uuid
+                          - profile-name
                           - string-profile-1-0:string-profile-pac
                         properties:
-                          core-model-1-4:uuid:
+                          uuid:
                             type: string
-                          core-model-1-4:profile-name:
+                          profile-name:
                             type: string
                             enum:
                               - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                              - 'file-profile-1-0:PROFILE_NAME_TYPE_FILE_PROFILE'
                               - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
                               - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                           string-profile-1-0:string-profile-pac:
@@ -6171,7 +6277,7 @@ paths:
                                   string-value:
                                     type: string
               example:
-              - core-model-1-4:profile:
+                core-model-1-4:profile:
                   uuid: 'ro-1-0-0-action-p-000'
                   profile-name: 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
                   action-profile-1-0:action-profile-pac:
@@ -6184,17 +6290,6 @@ paths:
                       display-in-new-browser-window: false
                     action-profile-configuration:
                       request: 'https://10.118.125.157:1000/v1/inform-about-application-in-generic-representation'
-              - core-model-1-4:profile:
-                  uuid: 'ro-1-0-0-integer-p-000'
-                  profile-name: 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                  integer-profile-1-0:integer-profile-pac:
-                    integer-profile-capability:
-                      integer-name: 'maximumNumberOfEntries'
-                      unit: 'records'
-                      minimum: 0
-                      maximum: 1000000
-                    integer-profile-configuration:
-                      integer-value: 1000000
         '400':
           $ref: '#/components/responses/responseForErroredOamRequests'
         '401':
@@ -6207,6 +6302,7 @@ paths:
           $ref: '#/components/responses/responseForErroredOamRequests'
         default:
           $ref: '#/components/responses/responseForErroredOamRequests'
+
 
   /core-model-1-4:control-construct/profile-collection/profile={uuid}/integer-profile-1-0:integer-profile-pac/integer-profile-capability/integer-name:
     parameters:
@@ -6448,6 +6544,400 @@ paths:
         default:
           $ref: '#/components/responses/responseForErroredOamRequests'
 
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/file-profile-1-0:file-profile-pac/file-profile-capability/file-identifier:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-file-p-([0-9]{3})$'
+          example: 'ro-1-0-0-file-p-000'
+    get:
+      operationId: getFileProfileFileIdentifier
+      summary: 'Returns the identifier of the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'File identifier provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - file-profile-1-0:file-identifier
+                properties:
+                  file-profile-1-0:file-identifier:
+                    type: string
+                    example: 'applicationData'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/file-profile-1-0:file-profile-pac/file-profile-capability/file-description:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-file-p-([0-9]{3})$'
+          example: 'ro-1-0-0-file-p-000'
+    get:
+      operationId: getFileProfileFileDescription
+      summary: 'Returns the description of the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'File description provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - file-profile-1-0:file-description
+                properties:
+                  file-profile-1-0:file-description:
+                    type: string
+                    example: 'Holds administrator-names, user-names, authorization codes and allowed-methods.'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/file-profile-1-0:file-profile-pac/file-profile-configuration/file-path:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-file-p-([0-9]{3})$'
+          example: 'ro-1-0-0-file-p-000'
+    get:
+      operationId: getFileProfileFilePath
+      summary: 'Returns the path of the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'File path provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - file-profile-1-0:file-path
+                properties:
+                  file-profile-1-0:file-path:
+                    type: string
+                    example: '../application-data/application-data.json'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+    put:
+      operationId: putFileProfileFilePath
+      summary: 'Configures path of the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - file-profile-1-0:file-path
+              properties:
+                file-profile-1-0:file-path:
+                  type: string
+                  example: '../application-data/application-data.json'
+      responses:
+        '204':
+          description: 'File path configured'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/file-profile-1-0:file-profile-pac/file-profile-configuration/user-name:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-file-p-([0-9]{3})$'
+          example: 'ro-1-0-0-file-p-000'
+    get:
+      operationId: getFileProfileUserName
+      summary: 'Returns the user name for acccessing the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'User name provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - file-profile-1-0:user-name
+                properties:
+                  file-profile-1-0:user-name:
+                    type: string
+                    example: 'firstname.surname'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+    put:
+      operationId: putFileProfileUserName
+      summary: 'Configures the user name for acccessing the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - file-profile-1-0:user-name
+              properties:
+                file-profile-1-0:user-name:
+                  type: string
+                  example: 'firstname.surname'
+      responses:
+        '204':
+          description: 'User name configured'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/file-profile-1-0:file-profile-pac/file-profile-configuration/password:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-file-p-([0-9]{3})$'
+          example: 'ro-1-0-0-file-p-000'
+    get:
+      operationId: getFileProfilePassword
+      summary: 'Returns the password for acccessing the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'Password provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - file-profile-1-0:password
+                properties:
+                  file-profile-1-0:password:
+                    type: string
+                    example: 'stupid_phrase'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+    put:
+      operationId: putFileProfilePassword
+      summary: 'Configures the password for acccessing the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - file-profile-1-0:password
+              properties:
+                file-profile-1-0:password:
+                  type: string
+                  example: 'stupid_phrase'
+      responses:
+        '204':
+          description: 'Password configured'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+  /core-model-1-4:control-construct/profile-collection/profile={uuid}/file-profile-1-0:file-profile-pac/file-profile-configuration/operation:
+    parameters:
+      - in: path
+        name: uuid
+        required: true
+        schema:
+          type: string
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-file-p-([0-9]{3})$'
+          example: 'ro-1-0-0-file-p-000'
+    get:
+      operationId: getFileProfileOperation
+      summary: 'Returns the allowed operation on the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      responses:
+        '200':
+          description: 'Operation provided'
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - file-profile-1-0:operation
+                properties:
+                  file-profile-1-0:operation:
+                    type: string
+                    enum:
+                      - 'file-profile-1-0:OPERATION_TYPE_READ_ONLY'
+                      - 'file-profile-1-0:OPERATION_TYPE_READ_WRITE'
+                      - 'file-profile-1-0:OPERATION_TYPE_OFF'
+                      - 'file-profile-1-0:OPERATION_TYPE_NOT_YET_DEFINED'
+                    example: 'file-profile-1-0:OPERATION_TYPE_READ_ONLY'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+    put:
+      operationId: putFileProfileOperation
+      summary: 'Configures the allowed operation on the file'
+      tags:
+        - FileProfile
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - file-profile-1-0:operation
+              properties:
+                file-profile-1-0:operation:
+                  type: string
+                  enum:
+                    - 'file-profile-1-0:OPERATION_TYPE_READ_ONLY'
+                    - 'file-profile-1-0:OPERATION_TYPE_READ_WRITE'
+                    - 'file-profile-1-0:OPERATION_TYPE_OFF'
+                    - 'file-profile-1-0:OPERATION_TYPE_NOT_YET_DEFINED'
+                  example: 'file-profile-1-0:OPERATION_TYPE_READ_WRITE'
+      responses:
+        '204':
+          description: 'Operation configured'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+
+
   /core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/elasticsearch-client-interface-1-0:elasticsearch-client-interface-pac/elasticsearch-client-interface-configuration/auth/api-key:
     parameters:
       - in: path
@@ -6455,8 +6945,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([bi][ms])-([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{3})$'
-          example: 'ro-1-0-0-op-c-bm-or-1-0-0-000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-es-c-im-([0-9]{3})$'
+          example: 'ro-1-0-0-es-c-im-000'
     get:
       operationId: getElasticsearchClientApiKey
       summary: 'Returns API key'
@@ -6529,8 +7019,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([bi][ms])-([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{3})$'
-          example: 'ro-1-0-0-op-c-bm-or-1-0-0-000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-es-c-im-([0-9]{3})$'
+          example: 'ro-1-0-0-es-c-im-000'
     get:
       operationId: getElasticsearchClientIndexAlias
       summary: 'Returns index alias'
@@ -6603,8 +7093,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([bi][ms])-([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{3})$'
-          example: 'ro-1-0-0-op-c-bm-or-1-0-0-000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-es-c-im-([0-9]{3})$'
+          example: 'ro-1-0-0-es-c-im-000'
     get:
       operationId: getElasticsearchClientServiceRecordsPolicy
       summary: 'Returns service records policy'
@@ -7295,8 +7785,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([bi][ms])-([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{3})$'
-          example: 'ro-1-0-0-op-c-bm-or-1-0-0-000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-es-c-im-([0-9]{3})$'
+          example: 'ro-1-0-0-es-c-im-000'
     get:
       operationId: getElasticsearchClientOperationalState
       summary: 'Returns operational state of the connection towards Elasticsearch'
@@ -7340,8 +7830,8 @@ paths:
         required: true
         schema:
           type: string
-          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-op-c-([bi][ms])-([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{3})$'
-          example: 'ro-1-0-0-op-c-bm-or-1-0-0-000'
+          pattern: '^([a-z]{2,6})-([0-9]{1,2})-([0-9]{1,2})-([0-9]{1,2})-es-c-im-([0-9]{3})$'
+          example: 'ro-1-0-0-es-c-im-000'
     get:
       operationId: getElasticsearchClientLifeCycleState
       summary: 'Returns life cycle state of the connection towards Elasticsearch'

--- a/ApplicationPattern.yaml
+++ b/ApplicationPattern.yaml
@@ -5064,13 +5064,9 @@ paths:
                                     profile-name:
                                       type: string
                                       enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
                                         - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                                     action-profile-1-0:action-profile-pac:
                                       type: object
                                       required:
@@ -5120,13 +5116,9 @@ paths:
                                     profile-name:
                                       type: string
                                       enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
                                         - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                                     integer-profile-1-0:integer-profile-pac:
                                       type: object
                                       required:
@@ -5165,13 +5157,9 @@ paths:
                                     profile-name:
                                       type: string
                                       enum:
-                                        - 'admin-profile-1-0:PROFILE_NAME_TYPE_ADMIN_PROFILE'
-                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
-                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
-                                        - 'application-profile-1-0:PROFILE_NAME_TYPE_APPLICATION_PROFILE'
-                                        - 'service-record-profile-1-0:PROFILE_NAME_TYPE_SERVICE_RECORD_PROFILE'
-                                        - 'oam-record-profile-1-0:PROFILE_NAME_TYPE_OAM_RECORD_PROFILE'
                                         - 'action-profile-1-0:PROFILE_NAME_TYPE_ACTION_PROFILE'
+                                        - 'integer-profile-1-0:PROFILE_NAME_TYPE_INTEGER_PROFILE'
+                                        - 'string-profile-1-0:PROFILE_NAME_TYPE_STRING_PROFILE'
                                     string-profile-1-0:string-profile-pac:
                                       type: object
                                       required:


### PR DESCRIPTION
Artifacts of obsolete Profiles removed
display-in-new-browser-window corrected
Wrong namespaces removed
uuid pattern in .../profile-collection/profile={uuid}: corrected

(contains also changes of parallel pull-request for adding a FileProfile)