### PR TITLE
Add PUT to OAM of application-name (Fixes #91)

### DIFF
--- a/ApplicationPattern+data.json
+++ b/ApplicationPattern+data.json
@@ -532,10 +532,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "OldRelease"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "OldRelease",
 										"release-number": " >>> ReleaseNumber of the existing release <<< "
 									}
 								}
@@ -580,10 +578,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "NewRelease"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "NewRelease",
 										"release-number": " >>> ReleaseNumber of the new release <<< "
 									}
 								}
@@ -732,11 +728,9 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "RegistryOffice"
-									},
 									"http-client-interface-configuration": {
-										"release-number": " >>> current release of RegistryOffice <<< "
+										"application-name": "RegistryOffice",
+                    "release-number": " >>> current release of RegistryOffice <<< "
 									}
 								}
 							}
@@ -780,10 +774,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "TypeApprovalRegister"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "TypeApprovalRegister",
 										"release-number": " >>> current release of TypeApprovalRegister <<< "
 									}
 								}
@@ -855,10 +847,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "ExecutionAndTraceLog"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "ExecutionAndTraceLog",
 										"release-number": " >>> current release of ExecutionAndTraceLog <<< "
 									}
 								}
@@ -929,10 +919,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "OamLog"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "OamLog",
 										"release-number": " >>> current release of OamLog <<< "
 									}
 								}
@@ -1003,10 +991,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "AdministratorAdministration"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "AdministratorAdministration",
 										"release-number": " >>> current release of AdministratorAdministration <<< "
 									}
 								}
@@ -1207,10 +1193,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "ApplicationLayerTopology"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "ApplicationLayerTopology",
 										"release-number": " >>> current release of ApplicationLayerTopology <<< "
 									}
 								}
@@ -1255,10 +1239,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "OperationKeyManagement"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "OperationKeyManagement",
 										"release-number": " >>> current release of OperationKeyManagement <<< "
 									}
 								}
@@ -1303,10 +1285,8 @@
 								"local-id": "0",
 								"layer-protocol-name": "http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER",
 								"http-client-interface-1-0:http-client-interface-pac": {
-									"http-client-interface-capability": {
-										"application-name": "CurrentController"
-									},
 									"http-client-interface-configuration": {
+                    "application-name": "CurrentController",
 										"release-number": " >>> current release of CurrentController <<< "
 									}
 								}

--- a/ApplicationPattern.yaml
+++ b/ApplicationPattern.yaml
@@ -37,7 +37,7 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall be target of the handover process
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-nr-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-nr-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 new-application-release:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -587,7 +587,7 @@ paths:
                   type: string
                   description: >
                     'If body provided, name of RegistryOffice application
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-ro-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-ro-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 registry-office-application-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -874,7 +874,7 @@ paths:
                   type: string
                   description: >
                     'Name of RegistryOffice application
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-ro-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-ro-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 registry-office-application-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -1158,7 +1158,7 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall record the service requests
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-eatl-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-eatl-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 service-log-application-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -1399,7 +1399,7 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall record the OaM requests
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-ol-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-ol-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 oam-log-application-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -1630,7 +1630,7 @@ paths:
                   type: string
                   description: >
                     'Name of application that no longer wants to receive notifications
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 subscriber-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -1723,13 +1723,13 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall approve the OaM requests
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-aa-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-aa-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 oam-approval-application-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
                   description: >
                     'Release of application that shall approve the OaM requests
-                    update or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-aa-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
+                    update [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-aa-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/release-number]'
                 oam-approval-operation:
                   type: string
                   minLength: 6
@@ -1975,7 +1975,7 @@ paths:
                   type: string
                   description: >
                     'Name of the application that has updated connection data
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 old-application-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -2311,21 +2311,16 @@ paths:
                                       http-client-interface-1-0:http-client-interface-pac:
                                         type: object
                                         required:
-                                          - http-client-interface-capability
                                           - http-client-interface-configuration
                                         properties:
-                                          http-client-interface-capability:
-                                            type: object
-                                            required:
-                                              - application-name
-                                            properties:
-                                              application-name:
-                                                type: string
                                           http-client-interface-configuration:
                                             type: object
                                             required:
+                                              - application-name
                                               - release-number
                                             properties:
+                                              application-name:
+                                                type: string
                                               release-number:
                                                 type: string
                                   - description: 'tcp client'
@@ -2549,7 +2544,7 @@ paths:
                   type: string
                   description: >
                     'Name of application that shall document the application layer topology
-                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-alt-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find or create [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-bm-alt-1-0-0-000/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 topology-application-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -2882,21 +2877,16 @@ paths:
                                             http-client-interface-1-0:http-client-interface-pac:
                                               type: object
                                               required:
-                                                - http-client-interface-capability
                                                 - http-client-interface-configuration
                                               properties:
-                                                http-client-interface-capability:
-                                                  type: object
-                                                  required:
-                                                    - application-name
-                                                  properties:
-                                                    application-name:
-                                                      type: string
                                                 http-client-interface-configuration:
                                                   type: object
                                                   required:
+                                                    - application-name
                                                     - release-number
                                                   properties:
+                                                    application-name:
+                                                      type: string
                                                     release-number:
                                                       type: string
                                         - description: 'tcp client'
@@ -3269,21 +3259,16 @@ paths:
                                   http-client-interface-1-0:http-client-interface-pac:
                                     type: object
                                     required:
-                                      - http-client-interface-capability
                                       - http-client-interface-configuration
                                     properties:
-                                      http-client-interface-capability:
-                                        type: object
-                                        required:
-                                          - application-name
-                                        properties:
-                                          application-name:
-                                            type: string
                                       http-client-interface-configuration:
                                         type: object
                                         required:
+                                          - application-name
                                           - release-number
                                         properties:
+                                          application-name:
+                                            type: string
                                           release-number:
                                             type: string
                               - description: 'tcp client'
@@ -3896,21 +3881,16 @@ paths:
                                   http-client-interface-1-0:http-client-interface-pac:
                                     type: object
                                     required:
-                                      - http-client-interface-capability
                                       - http-client-interface-configuration
                                     properties:
-                                      http-client-interface-capability:
-                                        type: object
-                                        required:
-                                          - application-name
-                                        properties:
-                                          application-name:
-                                            type: string
                                       http-client-interface-configuration:
                                         type: object
                                         required:
+                                          - application-name
                                           - release-number
                                         properties:
+                                          application-name:
+                                            type: string
                                           release-number:
                                             type: string
                               - description: 'tcp client'
@@ -4453,7 +4433,7 @@ paths:
                   type: string
                   description: >
                     'Name of the application that has an updated operation
-                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+                    find [/core-model-1-4:control-construct/logical-termination-point=*-1-0-0-http-c-*/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
                 application-release-number:
                   type: string
                   pattern: '^([0-9]{1,2})\.([0-9]{1,2})\.([0-9]{1,2})$'
@@ -5880,21 +5860,16 @@ paths:
                                       http-client-interface-1-0:http-client-interface-pac:
                                         type: object
                                         required:
-                                          - http-client-interface-capability
                                           - http-client-interface-configuration
                                         properties:
-                                          http-client-interface-capability:
-                                            type: object
-                                            required:
-                                              - application-name
-                                            properties:
-                                              application-name:
-                                                type: string
                                           http-client-interface-configuration:
                                             type: object
                                             required:
+                                              - application-name
                                               - release-number
                                             properties:
+                                              application-name:
+                                                type: string
                                               release-number:
                                                 type: string
                                   - description: 'tcp client'
@@ -5967,9 +5942,8 @@ paths:
                               - local-id: '0'
                                 layer-protocol-name: 'http-client-interface-1-0:LAYER_PROTOCOL_NAME_TYPE_HTTP_LAYER'
                                 http-client-interface-1-0:http-client-interface-pac:
-                                  http-client-interface-capability:
-                                    application-name: 'RegistryOffice'
                                   http-client-interface-configuration:
+                                    application-name: 'RegistryOffice'
                                     release-number: '1.0.0'
                       forwarding-domain:
                         type: array
@@ -9136,7 +9110,7 @@ paths:
         default:
           $ref: '#/components/responses/responseForErroredOamRequests'
 
-  /core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name:
+  /core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name:
     parameters:
       - in: path
         name: uuid
@@ -9165,6 +9139,41 @@ paths:
                   http-client-interface-1-0:application-name:
                     type: string
                     example: 'OldRelease'
+        '400':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '401':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '403':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '404':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        '500':
+          $ref: '#/components/responses/responseForErroredOamRequests'
+        default:
+          $ref: '#/components/responses/responseForErroredOamRequests'
+    put:
+      operationId: putHttpClientApplicationName
+      summary: 'Configures name of application to be addressed'
+      tags:
+        - HttpClient
+      security:
+        - basicAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - http-client-interface-1-0:application-name
+              properties:
+                http-client-interface-1-0:application-name:
+                  type: string
+                  minLength: 2
+                  example: 'NewApplication'
+      responses:
+        '204':
+          description: 'Name of addressed application configured'
         '400':
           $ref: '#/components/responses/responseForErroredOamRequests'
         '401':
@@ -9460,7 +9469,7 @@ components:
         example: 'Resolver'
       description: >
         'Identification for the system consuming the API, as defined in
-         [/core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-capability/application-name]'
+         [/core-model-1-4:control-construct/logical-termination-point={uuid}/layer-protocol=0/http-client-interface-1-0:http-client-interface-pac/http-client-interface-configuration/application-name]'
     x-correlator:
       name: x-correlator
       in: header

--- a/ApplicationPattern.yaml
+++ b/ApplicationPattern.yaml
@@ -9169,7 +9169,7 @@ paths:
               properties:
                 http-client-interface-1-0:application-name:
                   type: string
-                  minLength: 2
+                  minLength: 3
                   example: 'NewApplication'
       responses:
         '204':


### PR DESCRIPTION
application name in /v1/inquire-oam-request-approvals to be found, but no longer created.
application names now configurable via OAM during runtime.
uuids corrected to new info structure of httpClient.
