### PR TITLE
docs: Add L2LT to elastic search index alias

### DIFF
--- a/doc/TestingApplications/Infrastructure/SdnLaboratory/FakeAddresses/IndexAliases.md
+++ b/doc/TestingApplications/Infrastructure/SdnLaboratory/FakeAddresses/IndexAliases.md
@@ -7,6 +7,7 @@ The following fake Index Aliases have to be used in public documentation and spe
 | ElasticSearch 1.0.0 |  |  |  |  |
 |  | EaTL | ExecutionAndTraceLog | 2.0.0 | 3
 |  | OL | OamLog | 2.0.0 | 4
+|  | L2LT | LinkId2LtpTranslator | 1.0.0 | 5
 
 
 # Historical Fake Index Aliases  


### PR DESCRIPTION
The [LinkId2LtpTranslator](https://github.com/openBackhaul/Linkid2LtpTranslator) needs to store a lot of data and therefore needs an Elastic search client. I expanded the index alias list so it can be used in the L2LT service list.

fixes #673 