### PR TITLE
EATL-227 : fixed several errors found during testing

### DIFF
--- a/server/applicationPattern/applicationPattern/rest/client/eventDispatcher.js
+++ b/server/applicationPattern/applicationPattern/rest/client/eventDispatcher.js
@@ -33,6 +33,11 @@ exports.dispatchEvent = function (operationClientUuid, httpRequestBody, user, xC
                 operationClientUuid);
             let operationName = await OperationClientInterface.getOperationNameAsync(
                 operationClientUuid);
+            // we need information from the database at this stage, because the database might change
+            // before the response is received, see https://github.com/openBackhaul/ExecutionAndTraceLog/issues/227
+            let httpClientUuid = await LogicalTerminationPoint.getServerLtpListAsync(operationClientUuid);
+            let serverApplicationName = await HttpClientInterface.getApplicationNameAsync(httpClientUuid[0]);
+            let serverApplicationReleaseNumber = await HttpClientInterface.getReleaseNumberAsync(httpClientUuid[0]);
             let originator = await httpServerInterface.getApplicationNameAsync();
             let httpRequestHeader = new RequestHeader(
                 user, 
@@ -53,9 +58,6 @@ exports.dispatchEvent = function (operationClientUuid, httpRequestBody, user, xC
             if (responseCode.toString().startsWith("2")) {
                 result = true;
             } else if (responseCode.toString().startsWith("5")) {
-                let httpClientUuid = await LogicalTerminationPoint.getServerLtpListAsync(operationClientUuid);
-                let serverApplicationName = await HttpClientInterface.getApplicationNameAsync(httpClientUuid);
-                let serverApplicationReleaseNumber = await HttpClientInterface.getReleaseNumberAsync(httpClientUuid);
                 recordServiceRequestFromClient(serverApplicationName, serverApplicationReleaseNumber, xCorrelator, traceIndicator, user, originator, operationName, responseCode, httpRequestBody, response.data)
                     .catch((error) => console.log(`record service request ${JSON.stringify({
                         xCorrelator,

--- a/server/applicationPattern/applicationPattern/services/ExecutionAndTraceService.js
+++ b/server/applicationPattern/applicationPattern/services/ExecutionAndTraceService.js
@@ -45,7 +45,7 @@ exports.recordServiceRequestFromClient = function (serverApplicationName, server
             let response = await requestBuilder.BuildAndTriggerRestRequest(operationClientUuid, "POST", httpRequestHeader, httpRequestBody);
             let responseCodeValue = response.status.toString();
             if (response !== undefined && responseCodeValue.startsWith("2")) {
-                resolve(true);
+                return resolve(true);
             }
             console.log(`recordServiceRequestFromClient - record service request from client with body ${JSON.stringify(httpRequestBody)} failed with response status: ${response.status}`);
             resolve(false);
@@ -87,7 +87,7 @@ exports.recordServiceRequest = function (xCorrelator, traceIndicator, userName, 
             let response = await requestBuilder.BuildAndTriggerRestRequest(operationClientUuid, "POST", httpRequestHeader, httpRequestBody);
             let responseCodeValue = response.status.toString();
             if (response !== undefined && responseCodeValue.startsWith("2")) {
-                resolve(true);
+                return resolve(true);
             }
             console.log(`recordServiceRequest - record service request with body ${JSON.stringify(httpRequestBody)} failed with response status: ${response.status}`);
             resolve(false);

--- a/server/applicationPattern/applicationPattern/services/OamLogService.js
+++ b/server/applicationPattern/applicationPattern/services/OamLogService.js
@@ -51,7 +51,7 @@ exports.recordOamRequest = function (oamPath, requestBody, responseCode, authori
             let response = await requestBuilder.BuildAndTriggerRestRequest(operationClientUuid, "POST", httpRequestHeader, httpRequestBody);
             let responseCodeValue = response.status.toString();
             if (response !== undefined && responseCodeValue.startsWith("2")) {
-                resolve(true);
+                return resolve(true);
             }
             console.log(`recordOamRequest - record OAM request with body ${JSON.stringify(httpRequestBody)} failed with response status: ${response.status}`);
             resolve(false);


### PR DESCRIPTION
- httpClientUuid was not used as a list, but as a string
- information from database should be gathered when the information is present there, see comments in code
- several methods should do 'return resolve/reject' not just 'resolve/reject' as that will continue in the method

Fixes openBackhaul/ExecutionAndTraceLog#227