### PR TITLE
preceding-release-number is spelled incorrectly in callback of /v1/register-yourself

### DIFF
--- a/server/basicServices/basicServices/services/PrepareForwardingAutomation.js
+++ b/server/basicServices/basicServices/services/PrepareForwardingAutomation.js
@@ -113,7 +113,7 @@ exports.registerYourself = function (logicalTerminationPointconfigurationStatus,
 
             registrationApplicationRequestBody.tcpServerList = tcpServerList;
             registrationApplicationRequestBody.precedingApplicationName = oldApplicationName;
-            registrationApplicationRequestBody.precedingReleaseNumer = oldReleaseNumber;
+            registrationApplicationRequestBody.precedingReleaseNumber = oldReleaseNumber;
             registrationApplicationRequestBody = onfFormatter.modifyJsonObjectKeysToKebabCase(registrationApplicationRequestBody);
             forwardingAutomation = new forwardingConstructAutomationInput(
                 registrationApplicationForwardingName,


### PR DESCRIPTION
Fixes #734