### PR TITLE
Resolve change the method name  of resolveHttpTcpAndOperationClientUuidFromForwardingName in the utility/LogicalTerminationPoint.js

### DIFF
--- a/server/basicServices/basicServices/utility/LogicalTerminationPoint.js
+++ b/server/basicServices/basicServices/utility/LogicalTerminationPoint.js
@@ -9,7 +9,7 @@ const tcpClientInterface = require('onf-core-model-ap/applicationPattern/onfMode
 const httpClientInterface = require('onf-core-model-ap/applicationPattern/onfModel/models/layerProtocols/HttpClientInterface');
 
 
-exports.resolveHttpTcpAndOperationClientUuidFromForwardingName = function () {
+exports.resolveHttpTcpAndOperationClientUuidOfNewRelease = function () {
     return new Promise(async function (resolve, reject) {
         let forwardingName = 'PromptForBequeathingDataCausesTransferOfListOfApplications'
         try {


### PR DESCRIPTION
Fixes #754